### PR TITLE
SLING-7759 introducing FilterPredicate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -145,12 +145,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.5</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
         </dependency>

--- a/src/main/java/org/apache/sling/engine/EngineConstants.java
+++ b/src/main/java/org/apache/sling/engine/EngineConstants.java
@@ -156,9 +156,47 @@ public class EngineConstants {
     public static final String SLING_FILTER_SCOPE = "sling.filter.scope";
     
     /**
+     * Regular expression pattern for enabling a filter on a matching request path
      *@since 2.2, Sling Engine 2.4
      */
     public static final String SLING_FILTER_PATTERN = "sling.filter.pattern";
+
+
+    /**
+     * Regular expression pattern for enabling a filter on a matching request suffix
+     *@since Sling Engine 2.7
+     */
+    public static final String SLING_FILTER_PATTERN_SUFFIX = SLING_FILTER_PATTERN + ".suffix";
+
+    /**
+     * Set of selectors enabling a filter if contains one or more request selectors
+     *@since Sling Engine 2.7
+     */
+    public static final String SLING_FILTER_SELECTORS = "sling.filter.selectors";
+
+    /**
+     * Set of methods enabling a filter on contains request method
+     *@since Sling Engine 2.7
+     */
+    public static final String SLING_FILTER_METHODS = "sling.filter.methods";
+
+    /**
+     * Set of paths enabling a filter if contains request path
+     *@since Sling Engine 2.7
+     */
+    public static final String SLING_FILTER_PATHS = "sling.filter.paths";
+
+    /**
+     * Set of resource types enabling a filter if contains request resource type
+     *@since Sling Engine 2.7
+     */
+    public static final String SLING_FILTER_RESOURCETYPES = "sling.filter.resourceTypes";
+
+    /**
+     * Set of extensions enabling a filter if contains request extension
+     *@since Sling Engine 2.7
+     */
+    public static final String SLING_FILTER_EXTENSIONS = "sling.filter.extensions";
 
     /**
      * Filter scope value identifying a component level filter.

--- a/src/main/java/org/apache/sling/engine/impl/filter/AbstractSlingFilterChain.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/AbstractSlingFilterChain.java
@@ -29,8 +29,11 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestProgressTracker;
 import org.apache.sling.engine.impl.request.RequestData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractSlingFilterChain implements FilterChain {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSlingFilterChain.class);
 
     private FilterHandle[] filters;
 
@@ -64,9 +67,11 @@ public abstract class AbstractSlingFilterChain implements FilterChain {
                 FilterHandle filter = this.filters[this.current];
                 
                 if (filter.select(slingRequest)) {
+                    LOG.debug("{} got selected for this request", filter);
                     trackFilter(slingRequest, filter);
                     filter.getFilter().doFilter(slingRequest, slingResponse, this);
                 } else {
+                    LOG.debug("{} was not selected for this request", filter);
                     if (this.current == this.filters.length-1) {
                         this.render(slingRequest, slingResponse);
                     } else {

--- a/src/main/java/org/apache/sling/engine/impl/filter/FilterPredicate.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/FilterPredicate.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.engine.impl.filter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.Filter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_PATTERN;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_EXTENSIONS;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_METHODS;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_PATHS;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_RESOURCETYPES;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_SELECTORS;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_PATTERN_SUFFIX;
+
+/**
+ * Contains a set of predicates that helps testing whether to enable a filter for a request or not
+ * it can only be constructed from a filter service reference, from whose properties it builds its
+ * predicates
+ */
+public class FilterPredicate {
+    private static final Logger LOG = LoggerFactory.getLogger(FilterPredicate.class);
+
+    /**
+     * Predicate indicating for a given request if we should consider it.
+     */
+    interface RequestPredicate {
+        boolean test(SlingHttpServletRequest request);
+    }
+
+    /**
+     * sub predicate based on a pattern
+     */
+    abstract class RequestMatchesPredicate implements RequestPredicate {
+        Pattern pattern;
+        RequestMatchesPredicate(Pattern pattern){
+            this.pattern = pattern;
+        }
+        @Override
+        public boolean test(SlingHttpServletRequest request) {
+            return pattern.matcher(getItem(request)).matches();
+        }
+        abstract String getItem(SlingHttpServletRequest request);
+    }
+
+    /**
+     * sub predicate based on presence of a string into a collection
+     */
+    abstract class RequestContainPredicate implements RequestPredicate {
+        Collection<String> items;
+        RequestContainPredicate(Collection<String> items){
+            this.items = items;
+        }
+
+        @Override
+        public boolean test(SlingHttpServletRequest request) {
+            if (items.size() > 0){
+                return items.contains(getItem(request));
+            }
+            return false;
+        }
+
+        abstract String getItem(SlingHttpServletRequest request);
+    }
+
+    private static final String [] PREDICATES = new String[]{
+            SLING_FILTER_SELECTORS,
+            SLING_FILTER_PATHS,
+            SLING_FILTER_METHODS,
+            SLING_FILTER_EXTENSIONS,
+            SLING_FILTER_PATTERN_SUFFIX,
+            SLING_FILTER_PATTERN};
+
+    Collection<String> selectors;
+    Collection<String> extensions;
+    Collection<String> resourceTypes;
+    Collection<String> methods;
+    Collection<String> paths;
+    Pattern pathRegex;
+    Pattern suffixRegex;
+
+    List<RequestPredicate> predicates;
+
+    /*
+     * @param reference osgi service configuration
+     */
+    public FilterPredicate(ServiceReference<Filter> reference) {
+        try {
+            for (String key : PREDICATES) {
+                Object value = reference.getProperty(key);
+                if (value != null) {
+                    if (predicates == null) {
+                        predicates = new ArrayList<>();
+                    }
+                    if ((SLING_FILTER_PATTERN.equals(key))) {
+                        pathRegex = Pattern.compile((String) value);
+                        predicates.add(new RequestMatchesPredicate(pathRegex) {
+                            @Override
+                            public String getItem(SlingHttpServletRequest request) {
+                                String path = request.getRequestPathInfo().getResourcePath();
+                                return StringUtils.isBlank(path) ? "/" : path;
+                            }
+                        });
+                    } else if (SLING_FILTER_METHODS.equals(key)) {
+                        methods = Arrays.asList((String[]) value);
+                        predicates.add(new RequestContainPredicate(methods){
+                            @Override
+                            public String getItem(SlingHttpServletRequest request) {
+                                return request.getMethod();
+                            }
+                        });
+                    } else if (SLING_FILTER_PATTERN_SUFFIX.equals(key)) {
+                        suffixRegex = Pattern.compile((String) value);
+                        predicates.add(new RequestMatchesPredicate(suffixRegex) {
+                            @Override
+                            public String getItem(SlingHttpServletRequest request) {
+                                return request.getRequestPathInfo().getSuffix();
+                            }
+                        });
+                    } else if (SLING_FILTER_EXTENSIONS.equals(key)) {
+                        extensions = Arrays.asList((String[])value);
+                        predicates.add(new RequestContainPredicate(extensions) {
+                            @Override
+                            public String getItem(SlingHttpServletRequest request) {
+                                return request.getRequestPathInfo().getExtension();
+                            }
+                        });
+                    } else if (SLING_FILTER_PATHS.equals(key)) {
+                        paths = Arrays.asList((String[])value);
+                        predicates.add(new RequestContainPredicate(paths) {
+                            @Override
+                            public String getItem(SlingHttpServletRequest request) {
+                                return request.getRequestPathInfo().getResourcePath();
+                            }
+                        });
+                    } else if (SLING_FILTER_RESOURCETYPES.equals(key)) {
+                        resourceTypes = Arrays.asList((String[])value);
+                        if (resourceTypes.size() > 0) {
+                            predicates.add(new RequestPredicate() {
+                                @Override
+                                public boolean test(SlingHttpServletRequest request) {
+                                    for (String type : resourceTypes) {
+                                        if (request.getResource().isResourceType(type)) {
+                                            return true;
+                                        }
+                                    }
+                                    return false;
+                                }
+                            });
+                        }
+                    } else if (SLING_FILTER_SELECTORS.equals(key)) {
+                        selectors = Arrays.asList((String[])value);
+                        if (selectors.size() > 0) {
+                            predicates.add(new RequestPredicate() {
+                                @Override
+                                public boolean test(SlingHttpServletRequest request) {
+                                    String[] sels = request.getRequestPathInfo().getSelectors();
+                                    if (sels != null) {
+                                        for (String sel : sels) {
+                                            if (selectors.contains(sel)){
+                                                return true;
+                                            }
+                                        }
+                                    }
+                                    return false;
+                                }
+                            });
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("unable to build up filter predicate, will consider no predicate here", e);
+            predicates = null;
+        }
+    }
+
+    /**
+     * @param req request that is tested upon
+     * @return true if this instance's configuration match the request
+     */
+    boolean test(SlingHttpServletRequest req) {
+        LOG.debug("starting filter test against {} request", req);
+        boolean select = true;
+        if ((predicates != null) && (predicates.size() > 0)){//null in case there has been no predicate configuration for this filter
+            //in case it's not empty, all predicates present must pass
+            for (RequestPredicate p : predicates){
+                select &= p.test(req);
+                if (! select){
+                    break;
+                }
+            }
+        }
+        LOG.debug("selection of {} returned {}", this, select);
+        return select;
+    }
+
+    @Override
+    public String toString() {
+        return "FilterPredicate{" +
+                "methods='" + methods + '\'' +
+                ", pathRegex=" + pathRegex +
+                ", suffixRegex=" + suffixRegex +
+                ", selectors='" + selectors + '\'' +
+                ", extensions='" + extensions + '\'' +
+                ", paths='" + paths + '\'' +
+                '}';
+    }
+
+}

--- a/src/main/java/org/apache/sling/engine/impl/filter/ServletFilterManager.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/ServletFilterManager.java
@@ -222,7 +222,7 @@ public class ServletFilterManager extends ServiceTracker<Filter, Filter> {
             String[] scopes = OsgiUtil.toStringArray(
                     reference.getProperty(EngineConstants.SLING_FILTER_SCOPE), null);
 
-            String pattern = OsgiUtil.toString(reference.getProperty(EngineConstants.SLING_FILTER_PATTERN), "");
+            FilterPredicate predicate = new FilterPredicate(reference);
 
             if ( scopes == null ) {
                 scopes = OsgiUtil.toStringArray(
@@ -235,14 +235,14 @@ public class ServletFilterManager extends ServiceTracker<Filter, Filter> {
                     scope = scope.toUpperCase();
                     try {
                         FilterChainType type = FilterChainType.valueOf(scope.toString());
-                        getFilterChain(type).addFilter(filter, pattern, serviceId,
+                        getFilterChain(type).addFilter(filter, predicate, serviceId,
                             order, orderSource, mbean);
 
                         if (type == FilterChainType.COMPONENT) {
                             getFilterChain(FilterChainType.INCLUDE).addFilter(
-                                filter, pattern, serviceId, order, orderSource, mbean);
+                                filter, predicate, serviceId, order, orderSource, mbean);
                             getFilterChain(FilterChainType.FORWARD).addFilter(
-                                filter, pattern, serviceId, order, orderSource, mbean);
+                                filter, predicate, serviceId, order, orderSource, mbean);
                         }
 
                     } catch (IllegalArgumentException iae) {
@@ -253,7 +253,7 @@ public class ServletFilterManager extends ServiceTracker<Filter, Filter> {
                 log.warn(String.format(
                     "A Filter (Service ID %s) has been registered without a filter.scope property.",
                     reference.getProperty(Constants.SERVICE_ID)));
-                getFilterChain(FilterChainType.REQUEST).addFilter(filter, pattern,
+                getFilterChain(FilterChainType.REQUEST).addFilter(filter, predicate,
                     serviceId, order, orderSource,mbean);
             }
 

--- a/src/main/java/org/apache/sling/engine/impl/filter/SlingFilterChainHelper.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/SlingFilterChainHelper.java
@@ -42,7 +42,7 @@ public class SlingFilterChainHelper {
     SlingFilterChainHelper() {
     }
 
-    public synchronized Filter addFilter(final Filter filter,  String pattern,
+    public synchronized Filter addFilter(final Filter filter,  FilterPredicate pattern,
             final Long filterId, final int order, final String orderSource, FilterProcessorMBeanImpl mbean) {
         if (filterList == null) {
             filterList = new TreeSet<FilterHandle>();

--- a/src/main/java/org/apache/sling/engine/package-info.java
+++ b/src/main/java/org/apache/sling/engine/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-@org.osgi.annotation.versioning.Version("2.2.1")
+@org.osgi.annotation.versioning.Version("2.3.0")
 package org.apache.sling.engine;
 

--- a/src/test/java/org/apache/sling/engine/impl/filter/AbstractFilterTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/AbstractFilterTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.engine.impl.filter;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestPathInfo;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JMock;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.runner.RunWith;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
+
+import javax.servlet.Filter;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(JMock.class)
+public abstract class AbstractFilterTest {
+    protected final Mockery context = new JUnit4Mockery();
+    protected ServiceReference<Filter> mockService(Object... map){
+
+        final Map props = new HashMap();
+        for (int i = 0;  i < map.length; i += 2){
+            props.put(map[i], map[i + 1]);
+        }
+
+        ServiceReference<Filter> ref = new ServiceReference<Filter>() {
+            @Override
+            public Object getProperty(String key) {
+                return props.get(key);
+            }
+
+            @Override
+            public String[] getPropertyKeys() {
+                return new String[0];
+            }
+
+            @Override
+            public Bundle getBundle() {
+                return null;
+            }
+
+            @Override
+            public Bundle[] getUsingBundles() {
+                return new Bundle[0];
+            }
+
+            @Override
+            public boolean isAssignableTo(Bundle bundle, String className) {
+                return false;
+            }
+
+            @Override
+            public int compareTo(Object reference) {
+                return 0;
+            }
+        };
+        return ref;
+    }
+    protected SlingHttpServletRequest mockRequest(final String path,
+                                                  final String extension,
+                                                  final String[] selectors,
+                                                  final String method,
+                                                  final String suffix
+                                                  ) {
+        final RequestPathInfo info = context.mock(RequestPathInfo.class, "info " + path + extension + method + suffix);
+        context.checking(new Expectations() {{
+            allowing(info).getExtension();
+            will(returnValue(extension));
+            allowing(info).getSuffix();
+            will(returnValue(suffix));
+            allowing(info).getSelectors();
+            will(returnValue(selectors));
+            allowing(info).getResourcePath();
+            will(returnValue(path));
+        }});
+
+        final SlingHttpServletRequest req = context.mock(SlingHttpServletRequest.class, "req " + path + extension + method + suffix);
+        context.checking(new Expectations() {{
+            allowing(req).getRequestPathInfo();
+            will(returnValue(info));
+            allowing(req).getMethod();
+            will(returnValue(method));
+        }});
+        return req;
+    }
+    protected FilterPredicate predicate(Object... args){
+        FilterPredicate predicate = new FilterPredicate(mockService(args));
+        return predicate;
+    }
+
+    protected SlingHttpServletRequest whateverRequest() {
+        return mockRequest("/content/test/what/ever","json", new String[]{"test"}, "GET", null);
+    }
+}

--- a/src/test/java/org/apache/sling/engine/impl/filter/FilterHandleTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/FilterHandleTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.engine.impl.filter;
+
+import org.junit.Test;
+
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_PATTERN;
+import static org.junit.Assert.*;
+
+public class FilterHandleTest extends AbstractFilterTest {
+
+    /**
+     * a filter with no predicate should be selected always, a filter with select only if predicate is good
+     */
+    @Test
+    public void testSelect(){
+        FilterHandle handle = new FilterHandle(null, predicate(), 0L, 0, "", null);
+        assertTrue("filter should be selected when no predicate", handle.select(mockRequest("/content/test/no/predicate", null, null, null, null)));
+        handle = new FilterHandle(null, predicate(SLING_FILTER_PATTERN,"/content/test/.*"), 0L, 0, "", null);
+        assertTrue("filter should be selected when matching predicate", handle.select(mockRequest("/content/test/matching/predicate", null, null, null, null)));
+        handle = new FilterHandle(null, predicate(SLING_FILTER_PATTERN,"/content/foo/.*"), 0L, 0, "", null);
+        assertFalse("filter should not be selected when no matching predicate", handle.select(mockRequest("/content/test/no/matching/predicate", null, null, null, null)));
+    }
+}

--- a/src/test/java/org/apache/sling/engine/impl/filter/FilterPredicateTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/FilterPredicateTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.engine.impl.filter;
+
+import org.junit.Test;
+
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_EXTENSIONS;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_METHODS;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_PATHS;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_PATTERN;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_PATTERN_SUFFIX;
+import static org.apache.sling.engine.EngineConstants.SLING_FILTER_SELECTORS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FilterPredicateTest extends AbstractFilterTest {
+
+    /**
+     * This one is especially important because it represents >99% of the requests
+     */
+    @Test
+    public void testNoPredicate() {
+        assertTrue("predicate with no recognised configuration should pass", predicate().test(whateverRequest()));
+    }
+
+    @Test
+    public void testPathPattern() {
+        FilterPredicate predicate = predicate(SLING_FILTER_PATTERN,"/content/test/.*");
+        assertTrue("/content/test/foo should be selected", predicate.test(mockRequest("/content/test/foo","json", null, null, null)));
+        assertFalse("/content/bar/foo should not be selected", predicate.test(mockRequest("/content/bar/foo","json", null, null, null)));
+    }
+
+    @Test
+    public void testExtensions() {
+        FilterPredicate predicate = predicate(SLING_FILTER_PATTERN,
+                "/content/test/.*",
+                SLING_FILTER_EXTENSIONS,
+                new String[]{"txt","xml"});
+        assertTrue("/content/test/foo.txt should be selected", predicate.test(mockRequest("/content/test/foo","txt", null, null, null)));
+        assertFalse("/content/test/foo.json should not be selected", predicate.test(mockRequest("/content/test/foo","json", null, null, null)));
+    }
+
+    @Test
+    public void testSuffix() {
+        FilterPredicate predicate = predicate(SLING_FILTER_PATTERN,
+                "/content/test/.*",
+                SLING_FILTER_PATTERN_SUFFIX,
+                "/foo/.*");
+        assertTrue("/content/test/foo /foo/bar should be selected", predicate.test(mockRequest("/content/test/foo",null, null, null, "/foo/bar")));
+        assertFalse("/content/test/foo /bar/foo should not be selected", predicate.test(mockRequest("/content/test/foo",null, null, null, "/bar/foo")));
+    }
+
+    @Test
+    public void testMethod() {
+        FilterPredicate predicate = predicate(SLING_FILTER_PATTERN,
+                "/content/test/.*",
+                SLING_FILTER_METHODS,
+                new String[]{"POST","PUT"});
+        assertTrue("POST /content/test/foo should be selected", predicate.test(mockRequest("/content/test/foo",null, null, "POST", null)));
+        assertFalse("GET /content/test/foo should not be selected", predicate.test(mockRequest("/content/test/foo",null, null, "GET", null)));
+    }
+
+    @Test
+    public void testSelectors() {
+        FilterPredicate predicate = predicate(SLING_FILTER_PATTERN,
+                "/content/test/.*",
+                SLING_FILTER_SELECTORS,
+                new String[]{"test","foo","bar"});
+        assertTrue("POST /content/test/foo.foo.test.someother.json should be selected", predicate.test(mockRequest("/content/test/two","json", new String[]{"foo","test","someother"}, "POST", null)));
+        assertTrue("POST /content/test/foo.test.someother.json should be selected", predicate.test(mockRequest("/content/test/one","json", new String[]{"test","someother"}, "PUT", null)));
+        assertFalse("GET /content/test/foo.json should not be selected", predicate.test(mockRequest("/content/test/no","json",  null, "GET", null)));
+    }
+
+    @Test
+    public void testRootWithNoPath() {
+        FilterPredicate predicate = predicate(SLING_FILTER_PATTERN,"/");
+        assertTrue("'' path based request should be selected with a slash", predicate.test(mockRequest("",null, null, null, null)));
+    }
+
+    @Test
+    public void testPaths() {
+        FilterPredicate predicate = predicate(SLING_FILTER_PATHS,new String[]{"/content/foo","/content/test"});
+        assertTrue("POST /content/test.json should be selected", predicate.test(mockRequest("/content/test","json", null, "POST", null)));
+        assertFalse("POST /content/bar.json should not be selected", predicate.test(mockRequest("/content/bar","json", null, "POST", null)));
+    }
+
+    @Test
+    public void testToString() {
+        FilterPredicate predicate = predicate(SLING_FILTER_PATTERN, "/content/test",SLING_FILTER_EXTENSIONS, new String[]{"json"}, SLING_FILTER_METHODS, new String[]{"GET"});
+        String patternString = predicate.toString();
+        assertTrue("there should be /content/test in the string representation", patternString.contains("/content/test"));
+        assertTrue("there should be json in the string representation", patternString.contains("json"));
+        assertTrue("there should be GET in the string representation", patternString.contains("GET"));
+    }
+}


### PR DESCRIPTION
- extending sling.filter.pattern to other classic request attributes,
- FilterHandler aggregates a FilterPredicate that is tested for inclusion, with 0 to n sub-predicates based on filter configuration,
- added unit tests for most cases,
- added a dependency to commons-lang3 to remove as much boilerplate code as possible,
- added debug & error logs to help understanding presence/absence of a given filter