### PR TITLE
SLING-9378 - When internalRedirect and sling:match maps are added, filterPattern doesn't work

### DIFF
--- a/src/main/java/org/apache/sling/engine/impl/filter/FilterPredicate.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/FilterPredicate.java
@@ -131,11 +131,13 @@ public class FilterPredicate {
         LOG.debug("starting filter test against {} request", req);
         RequestPathInfo requestPathInfo = req.getRequestPathInfo();
         String path = requestPathInfo.getResourcePath();
+        String uri = req.getPathInfo();
         boolean select = anyElementMatches(methods, req.getMethod())
                 && anyElementMatches(selectors, requestPathInfo.getSelectors())
                 && anyElementMatches(extensions, requestPathInfo.getExtension())
                 && anyResourceTypeMatches(resourceTypes, req)
-                && patternMatches(pathRegex, path == null || path.isEmpty() ? "/" : path)
+                && (patternMatches(pathRegex, path == null || path.isEmpty() ? "/" : path)
+                || patternMatches(pathRegex, uri == null || uri.isEmpty() ? "/" : uri))
                 && patternMatches(suffixRegex, requestPathInfo.getSuffix());
         LOG.debug("selection of {} returned {}", this, select);
         return select;

--- a/src/test/java/org/apache/sling/engine/impl/filter/AbstractFilterTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/AbstractFilterTest.java
@@ -99,6 +99,8 @@ public abstract class AbstractFilterTest {
             will(returnValue(info));
             allowing(req).getMethod();
             will(returnValue(method));
+            allowing(req).getPathInfo();
+            will(returnValue(path));
         }});
         return req;
     }


### PR DESCRIPTION
SLING-9378 - When internalRedirect and sling:match maps are added, filterPattern doesn't work