### PR TITLE
SLING-11722 - The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API

### DIFF
--- a/src/main/java/org/apache/sling/engine/impl/Config.java
+++ b/src/main/java/org/apache/sling/engine/impl/Config.java
@@ -91,4 +91,17 @@ public @interface Config {
 
     @AttributeDefinition(name = "Servlet Name", description = "Optional name for the Sling main servlet registered by this component")
     String servlet_name();
+
+    @AttributeDefinition(name = "Protect Headers on Includes",
+            description = "When enabled, servlets included via the RequestDispatcher will not be able to change the " +
+                    "response status code or set headers. Any attempt to make a change is ignored. This behaviour can " +
+                    "be overridden per include via the 'protectHeadersOnInclude' RequestDispatcherOptions key.")
+    boolean sling_includes_protectheaders() default false;
+
+    @AttributeDefinition(name = "Check Content-Type overwrites",
+            description = "When enabled, in addition to not allowing servlets included via the RequestDispatcher to " +
+                    "change the response status code or set headers, it will also check explicit overrides of the " +
+                    "Content-Type header and will make the Sling Engine throw a RuntimeException when such an " +
+                    "override is detected.")
+    boolean sling_includes_checkcontenttype() default false;
 }

--- a/src/main/java/org/apache/sling/engine/impl/Config.java
+++ b/src/main/java/org/apache/sling/engine/impl/Config.java
@@ -98,7 +98,7 @@ public @interface Config {
                     "be overridden per include via the 'protectHeadersOnInclude' RequestDispatcherOptions key.")
     boolean sling_includes_protectheaders() default false;
 
-    @AttributeDefinition(name = "Check Content-Type overwrites",
+    @AttributeDefinition(name = "Check Content-Type overrides",
             description = "When enabled, in addition to not allowing servlets included via the RequestDispatcher to " +
                     "change the response status code or set headers, it will also check explicit overrides of the " +
                     "Content-Type header and will make the Sling Engine throw a RuntimeException when such an " +

--- a/src/main/java/org/apache/sling/engine/impl/IncludeNoContentTypeOverrideResponseWrapper.java
+++ b/src/main/java/org/apache/sling/engine/impl/IncludeNoContentTypeOverrideResponseWrapper.java
@@ -1,0 +1,74 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.engine.impl;
+
+import org.apache.sling.api.SlingException;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.request.RequestProgressTracker;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class IncludeNoContentTypeOverrideResponseWrapper extends IncludeResponseWrapper {
+
+    private final RequestProgressTracker requestProgressTracker;
+    private final String activeServletName;
+
+    /**
+     * Wraps a response object and throws a {@link RuntimeException} if {@link #setContentType(String)} is called with
+     * a value that would override the response's previous set value.
+     *
+     * @param wrappedResponse the response to be wrapped
+     */
+    public IncludeNoContentTypeOverrideResponseWrapper(@NotNull RequestProgressTracker requestProgressTracker,
+                                                       @NotNull String activeServletName,
+                                                       @NotNull SlingHttpServletResponse wrappedResponse) {
+        super(wrappedResponse);
+        this.requestProgressTracker = requestProgressTracker;
+        this.activeServletName = activeServletName;
+    }
+
+    @Override
+    public void setContentType(String type) {
+        String contentTypeString = getContentType();
+        if (contentTypeString != null) {
+            Optional<String> currentMime = Arrays.stream(contentTypeString.split(";")).findFirst();
+            Optional<String> setMime = Arrays.stream(type.split(";")).findFirst();
+            if (currentMime.isPresent() && setMime.isPresent() && !currentMime.get().equals(setMime.get())) {
+                String message = String.format(
+                        "Servlet %s tried to override the 'Content-Type' header from '%s' to '%s', however the %s forbids this via the %s configuration property.",
+                        activeServletName,
+                        currentMime.get(),
+                        setMime.get(),
+                        Config.PID,
+                        "sling.includes.checkcontenttype"
+                );
+                requestProgressTracker.log(message);
+                throw new ContentTypeChangeException(message);
+            }
+        }
+    }
+
+    private static class ContentTypeChangeException extends SlingException {
+        protected ContentTypeChangeException(String text) {
+            super(text);
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/engine/impl/IncludeNoContentTypeOverrideResponseWrapper.java
+++ b/src/main/java/org/apache/sling/engine/impl/IncludeNoContentTypeOverrideResponseWrapper.java
@@ -33,9 +33,12 @@ public class IncludeNoContentTypeOverrideResponseWrapper extends IncludeResponse
 
     /**
      * Wraps a response object and throws a {@link RuntimeException} if {@link #setContentType(String)} is called with
-     * a value that would override the response's previous set value.
+     * a value that would override the response's previously set value.
      *
-     * @param wrappedResponse the response to be wrapped
+     * @param requestProgressTracker the {@code RequestProgressTracker} used to log when an override of the {@code
+     *                               Content-Type} header is detected
+     * @param activeServletName      the name of the active servlet, used for logging
+     * @param wrappedResponse        the response to be wrapped
      */
     public IncludeNoContentTypeOverrideResponseWrapper(@NotNull RequestProgressTracker requestProgressTracker,
                                                        @NotNull String activeServletName,

--- a/src/main/java/org/apache/sling/engine/impl/SlingHttpServletRequestImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingHttpServletRequestImpl.java
@@ -124,7 +124,14 @@ public class SlingHttpServletRequestImpl extends HttpServletRequestWrapper imple
     @Override
     public RequestDispatcher getRequestDispatcher(Resource resource,
             RequestDispatcherOptions options) {
-        return (resource != null) ? new SlingRequestDispatcher(resource, options) : null;
+        return (resource != null) ?
+                new SlingRequestDispatcher(
+                        resource,
+                        options,
+                        requestData.protectHeadersOnInclude(),
+                        requestData.checkContentTypeOnInclude()
+                )
+                : null;
     }
 
     /**
@@ -141,7 +148,14 @@ public class SlingHttpServletRequestImpl extends HttpServletRequestWrapper imple
     @Override
     public RequestDispatcher getRequestDispatcher(String path,
             RequestDispatcherOptions options) {
-        return (path != null) ? new SlingRequestDispatcher(path, options) : null;
+        return (path != null) ?
+                new SlingRequestDispatcher(
+                        path,
+                        options,
+                        requestData.protectHeadersOnInclude(),
+                        requestData.checkContentTypeOnInclude()
+                )
+                : null;
     }
 
     /**

--- a/src/main/java/org/apache/sling/engine/impl/SlingRequestProcessorImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingRequestProcessorImpl.java
@@ -402,10 +402,7 @@ public class SlingRequestProcessorImpl implements SlingRequestProcessor {
                     cResponse = new IncludeResponseWrapper(cResponse);
                 }
                 if (checkContentTypeOnInclude) {
-                    cResponse = new IncludeNoContentTypeOverrideResponseWrapper(
-                                    requestData.getRequestProgressTracker(),
-                                    requestData.getActiveServletName(),
-                                    cResponse
+                    cResponse = new IncludeNoContentTypeOverrideResponseWrapper(requestData, cResponse
                     );
                 }
             }

--- a/src/main/java/org/apache/sling/engine/impl/helper/SlingServletContext.java
+++ b/src/main/java/org/apache/sling/engine/impl/helper/SlingServletContext.java
@@ -120,12 +120,17 @@ public class SlingServletContext implements ServletContext, ServletContextListen
 
     private volatile ServiceRegistration<ServletContext> registration;
 
+    private final boolean protectHeadersOnInclude;
+    private final boolean checkContentTypeOnInclude;
+
     @Activate
     public SlingServletContext(final Config config, 
         final BundleContext bundleContext,
         @Reference final ProductInfoProvider infoProvider) {
         this.bundleContext = bundleContext;
         this.productInfoProvider = infoProvider;
+        this.protectHeadersOnInclude = config.sling_includes_protectheaders();
+        this.checkContentTypeOnInclude = config.sling_includes_checkcontenttype();
         this.setup(config);
     }
 
@@ -415,7 +420,7 @@ public class SlingServletContext implements ServletContext, ServletContextListen
             return null;
         }
 
-        return new SlingRequestDispatcher(path, null);
+        return new SlingRequestDispatcher(path, null, protectHeadersOnInclude, checkContentTypeOnInclude);
     }
 
     /**

--- a/src/main/java/org/apache/sling/engine/impl/request/RequestData.java
+++ b/src/main/java/org/apache/sling/engine/impl/request/RequestData.java
@@ -107,6 +107,10 @@ public class RequestData {
     /** The original servlet Servlet Response object */
     private final SlingHttpServletResponse slingResponse;
 
+    private final boolean protectHeadersOnInclude;
+
+    private final boolean checkContentTypeOnInclude;
+
     /** The parameter support class */
     private ParameterSupport parameterSupport;
 
@@ -151,13 +155,17 @@ public class RequestData {
     }
 
     public RequestData(SlingRequestProcessorImpl slingRequestProcessor,
-            HttpServletRequest request, HttpServletResponse response) {
+            HttpServletRequest request, HttpServletResponse response,
+                       boolean protectHeadersOnInclude,
+                       boolean checkContentTypeOnInclude) {
         this.startTimestamp = System.currentTimeMillis();
 
         this.slingRequestProcessor = slingRequestProcessor;
 
         this.servletRequest = request;
         this.servletResponse = response;
+        this.protectHeadersOnInclude = protectHeadersOnInclude;
+        this.checkContentTypeOnInclude = checkContentTypeOnInclude;
 
         this.slingRequest = new SlingHttpServletRequestImpl(this, this.servletRequest);
 
@@ -580,6 +588,14 @@ public class RequestData {
 
     public int getServletCallCount() {
         return servletCallCounter;
+    }
+
+    public boolean protectHeadersOnInclude() {
+        return protectHeadersOnInclude;
+    }
+
+    public boolean checkContentTypeOnInclude() {
+        return checkContentTypeOnInclude;
     }
 
     /**

--- a/src/main/java/org/apache/sling/engine/impl/request/SlingRequestDispatcher.java
+++ b/src/main/java/org/apache/sling/engine/impl/request/SlingRequestDispatcher.java
@@ -43,22 +43,31 @@ public class SlingRequestDispatcher implements RequestDispatcher {
 
     private Resource resource;
 
-    private RequestDispatcherOptions options;
+    private final RequestDispatcherOptions options;
 
-    private String path;
+    private final String path;
 
-    public SlingRequestDispatcher(String path, RequestDispatcherOptions options) {
+    private final boolean protectHeadersOnInclude;
+    private final boolean checkContentTypeOnInclude;
+
+    public SlingRequestDispatcher(String path, RequestDispatcherOptions options,
+                                  boolean protectHeadersOnInclude,
+                                  boolean checkContentTypeOnInclude) {
         this.path = path;
         this.options = options;
         this.resource = null;
+        this.protectHeadersOnInclude = protectHeadersOnInclude;
+        this.checkContentTypeOnInclude = checkContentTypeOnInclude;
     }
 
-    public SlingRequestDispatcher(Resource resource,
-            RequestDispatcherOptions options) {
-
+    public SlingRequestDispatcher(Resource resource, RequestDispatcherOptions options,
+                                  boolean protectHeadersOnInclude,
+                                  boolean checkContentTypeOnInclude) {
         this.resource = resource;
         this.options = options;
         this.path = resource.getPath();
+        this.protectHeadersOnInclude = protectHeadersOnInclude;
+        this.checkContentTypeOnInclude = checkContentTypeOnInclude;
     }
 
     @Override
@@ -214,9 +223,11 @@ public class SlingRequestDispatcher implements RequestDispatcher {
         SlingRequestPathInfo info = getMergedRequestPathInfo(cRequest);
         requestProgressTracker.log(
             "Including resource {0} ({1})", resource, info);
-        final boolean protectHeaders = this.options != null ? this.options.isProtectHeadersOnInclude() : false;
+        boolean protectHeaders = this.options != null ?
+                Boolean.parseBoolean(this.options.getOrDefault(RequestDispatcherOptions.OPT_PROTECT_HEADERS_ON_INCLUDE, String.valueOf(this.protectHeadersOnInclude)))
+                : this.protectHeadersOnInclude;
         rd.getSlingRequestProcessor().dispatchRequest(request, response, resource,
-            info, include, protectHeaders);
+            info, include, protectHeaders, this.checkContentTypeOnInclude);
     }
 
     /**

--- a/src/test/java/org/apache/sling/engine/impl/IncludeNoContentTypeOverrideResponseWrapperTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/IncludeNoContentTypeOverrideResponseWrapperTest.java
@@ -21,12 +21,12 @@ package org.apache.sling.engine.impl;
 
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestProgressTracker;
+import org.apache.sling.engine.impl.request.RequestData;
 import org.junit.Test;
 
-import javax.servlet.ServletException;
-import java.io.IOException;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,14 +35,17 @@ public class IncludeNoContentTypeOverrideResponseWrapperTest {
     private static final String ACTIVE_SERVLET_NAME = "activeServlet";
 
     @Test
-    public void testContentTypeOverrideThrows() throws ServletException, IOException {
+    public void testContentTypeOverrideThrows() {
+        RequestData requestData = mock(RequestData.class);
+        when(requestData.getActiveServletName()).thenReturn(ACTIVE_SERVLET_NAME);
         RequestProgressTracker requestProgressTracker = mock(RequestProgressTracker.class);
+        when(requestData.getRequestProgressTracker()).thenReturn(requestProgressTracker);
         SlingHttpServletResponse response = mock(SlingHttpServletResponse.class);
         when(response.getContentType()).thenReturn("text/html");
 
 
-        IncludeNoContentTypeOverrideResponseWrapper wrapper = new IncludeNoContentTypeOverrideResponseWrapper(
-                requestProgressTracker, ACTIVE_SERVLET_NAME, response
+        IncludeNoContentTypeOverrideResponseWrapper wrapper = new IncludeNoContentTypeOverrideResponseWrapper(requestData,
+                response
         );
 
         Throwable throwable = null;
@@ -58,14 +61,17 @@ public class IncludeNoContentTypeOverrideResponseWrapperTest {
     }
 
     @Test
-    public void testContentTypeOverrideLenient() throws ServletException, IOException {
+    public void testContentTypeOverrideLenient() {
+        RequestData requestData = mock(RequestData.class);
+        when(requestData.getActiveServletName()).thenReturn(ACTIVE_SERVLET_NAME);
         RequestProgressTracker requestProgressTracker = mock(RequestProgressTracker.class);
+        when(requestData.getRequestProgressTracker()).thenReturn(requestProgressTracker);
         SlingHttpServletResponse response = mock(SlingHttpServletResponse.class);
         when(response.getContentType()).thenReturn("text/html");
 
 
-        IncludeNoContentTypeOverrideResponseWrapper wrapper = new IncludeNoContentTypeOverrideResponseWrapper(
-                requestProgressTracker, ACTIVE_SERVLET_NAME, response
+        IncludeNoContentTypeOverrideResponseWrapper wrapper = new IncludeNoContentTypeOverrideResponseWrapper(requestData,
+                response
         );
 
         Throwable throwable = null;

--- a/src/test/java/org/apache/sling/engine/impl/IncludeNoContentTypeOverrideResponseWrapperTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/IncludeNoContentTypeOverrideResponseWrapperTest.java
@@ -1,0 +1,81 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.engine.impl;
+
+
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.request.RequestProgressTracker;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IncludeNoContentTypeOverrideResponseWrapperTest {
+
+    private static final String ACTIVE_SERVLET_NAME = "activeServlet";
+
+    @Test
+    public void testContentTypeOverrideThrows() throws ServletException, IOException {
+        RequestProgressTracker requestProgressTracker = mock(RequestProgressTracker.class);
+        SlingHttpServletResponse response = mock(SlingHttpServletResponse.class);
+        when(response.getContentType()).thenReturn("text/html");
+
+
+        IncludeNoContentTypeOverrideResponseWrapper wrapper = new IncludeNoContentTypeOverrideResponseWrapper(
+                requestProgressTracker, ACTIVE_SERVLET_NAME, response
+        );
+
+        Throwable throwable = null;
+        try {
+            wrapper.setContentType("application/json");
+        } catch (Throwable t) {
+            throwable = t;
+        }
+        assertNotNull(throwable);
+        assertEquals("Servlet activeServlet tried to override the 'Content-Type' header from 'text/html' to " +
+                "'application/json', however the org.apache.sling.engine.impl.SlingMainServlet forbids this via the " +
+                "sling.includes.checkcontenttype configuration property.", throwable.getMessage());
+    }
+
+    @Test
+    public void testContentTypeOverrideLenient() throws ServletException, IOException {
+        RequestProgressTracker requestProgressTracker = mock(RequestProgressTracker.class);
+        SlingHttpServletResponse response = mock(SlingHttpServletResponse.class);
+        when(response.getContentType()).thenReturn("text/html");
+
+
+        IncludeNoContentTypeOverrideResponseWrapper wrapper = new IncludeNoContentTypeOverrideResponseWrapper(
+                requestProgressTracker, ACTIVE_SERVLET_NAME, response
+        );
+
+        Throwable throwable = null;
+        try {
+            wrapper.setContentType("text/html;utf-8");
+        } catch (Throwable t) {
+            throwable = t;
+        }
+        assertNull(throwable);
+        assertEquals("text/html", wrapper.getContentType());
+    }
+
+}

--- a/src/test/java/org/apache/sling/engine/impl/filter/AbstractSlingFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/AbstractSlingFilterChainTest.java
@@ -65,7 +65,7 @@ public class AbstractSlingFilterChainTest extends AbstractFilterTest {
         };
         HttpServletRequest httpReq = whateverRequest();
         final RequestData requestData = new RequestData(new SlingRequestProcessorImpl(), httpReq,
-                context.mock(HttpServletResponse.class));
+                context.mock(HttpServletResponse.class), false, false);
         final SlingHttpServletRequestImpl req = new SlingHttpServletRequestImpl(requestData, httpReq);
         boolean illegalStateCaught = false;
         try {

--- a/src/test/java/org/apache/sling/engine/impl/request/InitResourceTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/request/InitResourceTest.java
@@ -118,7 +118,7 @@ public class InitResourceTest {
             will(returnValue(Collections.emptyList()));
         }});
 
-        requestData = new RequestData(processor, req, resp);
+        requestData = new RequestData(processor, req, resp, false, false);
     }
 
     @Test

--- a/src/test/java/org/apache/sling/engine/impl/request/RequestDataTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/request/RequestDataTest.java
@@ -101,7 +101,7 @@ public class RequestDataTest {
         }});
 
         
-        requestData = new RequestData(processor, req, resp) {
+        requestData = new RequestData(processor, req, resp, false, false) {
             @Override
             public ContentData getContentData() {
                 return contentData;


### PR DESCRIPTION
* added two new configuration options to the Sling Main Servlet: sling.includes.protectheaders and sling.includes.checkcontenttype
* the former doesn't allow included servlets to set a status code or response headers, whereas the latter also makes the Sling Engine throw a RuntimeException every time an included servlet tries to override the Content-Type response header
* sling.includes.protectheaders can be overridden per include, using the RequestDispatcherOptions