### PR TITLE
SLING-11722 - The SlingRequestDispatcher doesn't correctly implement the RequestDispatcher API

### DIFF
--- a/src/main/java/org/apache/sling/engine/impl/Config.java
+++ b/src/main/java/org/apache/sling/engine/impl/Config.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.engine.impl;
 
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
@@ -99,9 +101,7 @@ public @interface Config {
     boolean sling_includes_protectheaders() default false;
 
     @AttributeDefinition(name = "Check Content-Type overrides",
-            description = "When enabled, in addition to not allowing servlets included via the RequestDispatcher to " +
-                    "change the response status code or set headers, it will also check explicit overrides of the " +
-                    "Content-Type header and will make the Sling Engine throw a RuntimeException when such an " +
-                    "override is detected.")
+            description = "When enabled, it will check explicit overrides of the Content-Type header and will make the " +
+                    "Sling Engine throw a RuntimeException when such an override is detected.")
     boolean sling_includes_checkcontenttype() default false;
 }


### PR DESCRIPTION
* the IncludeNoContentTypeOverrideResponseWrapper will only report on Content-Type overrides, but will not prevent included servlets from setting other headers or the status code

I've updated the code so that the two `sling.includes.*` settings augment each other. The `sling.includes.protectheaders` will not allow included servlets to set the status code or set any headers. `sling.includes.checkcontenttype` on the other hand will now only be limited to throwing a `RuntimeException` if a `Content-Type` override is detected.

A fully compliant setup must have `sling.includes.protectheaders` set to `true`. This might not work for all Sling applications, but on a case-by-case basis it could be enabled.

`sling.includes.checkcontenttype` will help detect scenarios where the initial output has a different content type than what an included servlets wants to append to the response.