### PR TITLE
SLING-11825 SlingHttpServletRequestImpl.getUserPrincipal() must return

### DIFF
--- a/src/main/java/org/apache/sling/engine/impl/SlingHttpServletRequestImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingHttpServletRequestImpl.java
@@ -318,6 +318,10 @@ public class SlingHttpServletRequestImpl extends HttpServletRequestWrapper imple
      */
     @Override
     public Principal getUserPrincipal() {
+        // always return null for anonymous user
+        if (this.getRemoteUser() == null) {
+            return null;
+        }
         Principal principal = getResourceResolver().adaptTo(Principal.class);
         if (principal != null) {
             return principal;

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletRequestImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletRequestImplTest.java
@@ -50,7 +50,7 @@ public class SlingHttpServletRequestImplTest {
     }};
     
     @Test
-    public void getUserPrincipal_test() {
+    public void getUserPrincipal_testWithRemoteUserFallback() {
         final HttpServletRequest servletRequest = context.mock(HttpServletRequest.class);
         
         context.checking(new Expectations() {{
@@ -77,7 +77,7 @@ public class SlingHttpServletRequestImplTest {
     }
 
     @Test
-    public void getUserPrincipal_test2() {
+    public void getUserPrincipal_testUnauthenticated() {
         final HttpServletRequest servletRequest = context.mock(HttpServletRequest.class);
         
         context.checking(new Expectations() {{
@@ -91,12 +91,13 @@ public class SlingHttpServletRequestImplTest {
         
         final RequestData requestData = context.mock(RequestData.class, "requestData");        
         final ResourceResolver resourceResolver = context.mock(ResourceResolver.class);
+        final Principal principal = context.mock(Principal.class);
         
         context.checking(new Expectations() {{
             allowing(requestData).getResourceResolver();
             will(returnValue(resourceResolver));
             allowing(resourceResolver).adaptTo(Principal.class);
-            will(returnValue(null));
+            will(returnValue(principal));
         }});
         
         slingHttpServletRequestImpl = new SlingHttpServletRequestImpl(requestData, servletRequest);
@@ -104,7 +105,7 @@ public class SlingHttpServletRequestImplTest {
     }
     
     @Test
-    public void getUserPrincipal_test3() {
+    public void getUserPrincipal_testWithPrincipal() {
         final HttpServletRequest servletRequest = context.mock(HttpServletRequest.class);
         
         context.checking(new Expectations() {{
@@ -112,6 +113,8 @@ public class SlingHttpServletRequestImplTest {
             will(returnValue("/path"));
             allowing(servletRequest).getPathInfo();
             will(returnValue("/path"));
+            allowing(servletRequest).getRemoteUser();
+            will(returnValue("remoteUser"));
         }});
         
         final RequestData requestData = context.mock(RequestData.class, "requestData");        


### PR DESCRIPTION
null for unauthenticated requests