### PR TITLE
SLING-11903 - Sling Engine build fails on Java 17 due to JMock error:module java.base does not "opens java.lang" to unnamed module @2613a93a

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>org.jmock</groupId>
             <artifactId>jmock-junit4</artifactId>
-            <version>2.8.2</version>
+            <version>2.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -186,24 +186,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math</artifactId>
             <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jmock</groupId>
-            <artifactId>jmock-legacy</artifactId>
-            <version>2.8.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>2.1_3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.objenesis</groupId>
-            <artifactId>objenesis</artifactId>
-            <version>1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletRequestImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletRequestImplTest.java
@@ -35,8 +35,8 @@ import org.apache.sling.engine.impl.request.ContentData;
 import org.apache.sling.engine.impl.request.RequestData;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit4.JUnit4Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -46,7 +46,7 @@ public class SlingHttpServletRequestImplTest {
     SlingHttpServletRequestImpl slingHttpServletRequestImpl;
     
     private Mockery context = new JUnit4Mockery() {{
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }};
     
     @Test

--- a/src/test/java/org/apache/sling/engine/impl/helper/ExternalServletContextWrapperTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/helper/ExternalServletContextWrapperTest.java
@@ -38,8 +38,8 @@ import org.apache.sling.engine.impl.helper.ExternalServletContextWrapper.Request
 import org.apache.sling.engine.impl.request.RequestData;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit4.JUnit4Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class ExternalServletContextWrapperTest {
 
     @Before
     public void setup() {
-        context.setImposteriser(ClassImposteriser.INSTANCE);
+        context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     /**

--- a/src/test/java/org/apache/sling/engine/impl/request/InitResourceTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/request/InitResourceTest.java
@@ -28,7 +28,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.engine.impl.SlingRequestProcessorImpl;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,7 +76,7 @@ public class InitResourceTest {
     @Before
     public void setup() throws Exception {
         context = new Mockery() {{
-            setImposteriser(ClassImposteriser.INSTANCE);
+            setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         }};
 
         req = context.mock(HttpServletRequest.class);

--- a/src/test/java/org/apache/sling/engine/impl/request/RequestDataTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/request/RequestDataTest.java
@@ -34,7 +34,7 @@ import org.apache.sling.engine.impl.SlingHttpServletResponseImpl;
 import org.apache.sling.engine.impl.SlingRequestProcessorImpl;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -55,7 +55,7 @@ public class RequestDataTest {
     @Before
     public void setup() throws ServletException, IOException {
         context = new Mockery() {{
-            setImposteriser(ClassImposteriser.INSTANCE);
+            setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         }};
 
         req = context.mock(HttpServletRequest.class);


### PR DESCRIPTION
- update to the latest jmock-junit4
- switch from the ClassImposteriser to the ByteBuddyClassImposteriser
- drop no longer used jmock-legacy, cglib-nodep and objenesis dependencies