### PR TITLE
SLING-12454 - Allow configuring the warning severity of scripts that don't obey the RequestDispatcher include API

### DIFF
--- a/src/main/java/org/apache/sling/engine/impl/Config.java
+++ b/src/main/java/org/apache/sling/engine/impl/Config.java
@@ -116,7 +116,8 @@ public @interface Config {
     @AttributeDefinition(
             name = "Check Content-Type overrides",
             description = "When enabled, it will check explicit overrides of the Content-Type header and will make the "
-                    + "Sling Engine throw a RuntimeException when such an override is detected.")
+                    + "Sling Engine throw a RuntimeException when such an override is detected; otherwise the "
+                    + "Sling Engine will only log these cases on WARN.")
     boolean sling_includes_checkcontenttype() default false;
 
     @AttributeDefinition(


### PR DESCRIPTION
* warn if a `content-type` override is detected and `sling.includes.checkcontenttype` is set to `false` (default), otherwise throw an exception (the behaviour implemented in SLING-11722)