### PR TITLE
SLING-12661 use last 500 messages only for potential origins matching

### DIFF
--- a/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
@@ -363,7 +363,7 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
     }
 
     private List<String> getLastMessagesOfProgressTracker() {
-        // Collect the last N messages from the RequestProgressTracker to avoid OOM
+        // Collect the last MAX_NR_OF_MESSAGES messages from the RequestProgressTracker to prevent excessive memory consumption
         // errors when close to infinite recursive calls are made
         int nrOfOriginalMessages = 0;
         boolean gotCut = false;

--- a/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
@@ -31,14 +31,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.Spliterators;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.apache.sling.api.SlingException;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -67,6 +66,8 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
     }
 
     private static final Exception FLUSHER_STACK_DUMMY = new Exception();
+
+    private static final int MAX_NR_OF_MESSAGES = 500;
 
     private Exception flusherStacktrace;
 
@@ -361,13 +362,36 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
         return Optional.empty();
     }
 
+    private List<String> getLastMessagesOfProgressTracker() {
+        // Collect the last N messages from the RequestProgressTracker to avoid OOM
+        // errors when close to infinite recursive calls are made
+        int nrOfOriginalMessages = 0;
+        boolean gotCut = false;
+        Iterator<String> messagesIterator =
+                requestData.getRequestProgressTracker().getMessages();
+        LinkedList<String> lastMessages = new LinkedList<>();
+        while (messagesIterator.hasNext()) {
+            nrOfOriginalMessages++;
+            if (gotCut || lastMessages.size() >= MAX_NR_OF_MESSAGES) {
+                lastMessages.removeFirst();
+                gotCut = true;
+            }
+            lastMessages.add(messagesIterator.next());
+        }
+
+        if (gotCut) {
+            lastMessages.addFirst("... cut " + (nrOfOriginalMessages - MAX_NR_OF_MESSAGES) + " messages ...");
+        }
+        return lastMessages;
+    }
+
     /**
      * Finds unmatched TIMER_START messages in a log of messages.
      *
      * @return a string containing the unmatched TIMER_START messages
      */
     private String findUnmatchedTimerStarts() {
-        Iterator<String> messages = requestData.getRequestProgressTracker().getMessages();
+        Iterator<String> messages = getLastMessagesOfProgressTracker().iterator();
         List<String> unmatchedStarts = new ArrayList<>();
         Deque<String> timerDeque = new ArrayDeque<>();
 
@@ -418,15 +442,14 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
      * include.
      *
      * @param currentContentType the current 'Content-Type' header
-     * @param setContentType the 'Content-Type' header that is being set
+     * @param setContentType     the 'Content-Type' header that is being set
      */
     private String getMessage(@Nullable String currentContentType, @Nullable String setContentType) {
         String unmatchedStartTimers = findUnmatchedTimerStarts();
-        String allMessages = StreamSupport.stream(
-                        Spliterators.spliteratorUnknownSize(
-                                requestData.getRequestProgressTracker().getMessages(), 0),
-                        false)
-                .collect(Collectors.joining(System.lineSeparator()));
+
+        String allMessages =
+                getLastMessagesOfProgressTracker().stream().collect(Collectors.joining(System.lineSeparator()));
+
         if (!isCheckContentTypeOnInclude()) {
             return String.format(
                     "Servlet %s tried to override the 'Content-Type' header from '%s' to '%s'. This is a violation of "

--- a/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
@@ -363,8 +363,8 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
     }
 
     private List<String> getLastMessagesOfProgressTracker() {
-        // Collect the last MAX_NR_OF_MESSAGES messages from the RequestProgressTracker to prevent excessive memory consumption
-        // errors when close to infinite recursive calls are made
+        // Collect the last MAX_NR_OF_MESSAGES messages from the RequestProgressTracker to prevent excessive memory
+        // consumption errors when close to infinite recursive calls are made
         int nrOfOriginalMessages = 0;
         boolean gotCut = false;
         Iterator<String> messagesIterator =

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -110,6 +110,7 @@ public class SlingHttpServletResponseImplTest {
             "4673 LOG Applying Includefilters"
         };
 
+// build a string array which resembles the log of recursive includes (50 levels deep)
         String[] concatenatedArray = Stream.concat(Arrays.stream(logMessages), Arrays.stream(recursivePartStrings))
                 .toArray(String[]::new);
         for (int i = 0; i < 50; i++) {

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -108,7 +108,7 @@ public class SlingHttpServletResponseImplTest {
         Mockito.verifyNoMoreInteractions(orig);
     }
 
-    private String callTesteeAndGetLogMessage(String[] logMessages) {
+    private String callTesteeAndGetRequestProgressTrackerMessage(String[] logMessages) {
         final SlingHttpServletResponse orig = Mockito.mock(SlingHttpServletResponse.class);
         final RequestData requestData = mock(RequestData.class);
         final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
@@ -153,7 +153,7 @@ public class SlingHttpServletResponseImplTest {
                     .toArray(String[]::new);
         }
 
-        String logMessage = callTesteeAndGetLogMessage(concatenatedArray);
+        String logMessage = callTesteeAndGetRequestProgressTrackerMessage(concatenatedArray);
 
         // validate that the log message is cut off and only the last MAX_NR_OF_MESSAGES
         // remain in the log message, check for the cut message
@@ -162,7 +162,7 @@ public class SlingHttpServletResponseImplTest {
 
     @Test
     public void testContentMethods() {
-        String logMessage = callTesteeAndGetLogMessage(logMessages);
+        String logMessage = callTesteeAndGetRequestProgressTrackerMessage(logMessages);
         assertEquals(
                 String.format(
                         "ERROR: Servlet %s tried to override the 'Content-Type' header from 'null' to 'text/plain'. This is a violation of the RequestDispatcher.include() contract - https://jakarta.ee/specifications/servlet/4.0/apidocs/javax/servlet/requestdispatcher#include-javax.servlet.ServletRequest-javax.servlet.ServletResponse-. , Include stack: /libs/slingshot/Component/head.html.jsp#1 -> /libs/slingshot/Home/html.jsp#0. All RequestProgressTracker messages: %s",

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -86,6 +86,28 @@ public class SlingHttpServletResponseImplTest {
         "4749 LOG Adding bindings took 4 microseconds"
     };
 
+    @Test
+    public void testReset() {
+        final SlingHttpServletResponse orig = mock(SlingHttpServletResponse.class);
+        final RequestData requestData = mock(RequestData.class);
+        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
+        when(requestData.getDispatchingInfo()).thenReturn(info);
+        info.setProtectHeadersOnInclude(true);
+
+        final HttpServletResponse include = new SlingHttpServletResponseImpl(requestData, orig);
+
+        when(orig.isCommitted()).thenReturn(false);
+        include.reset();
+        verify(orig, times(1)).isCommitted();
+        Mockito.verifyNoMoreInteractions(orig);
+
+        when(orig.isCommitted()).thenReturn(true);
+        include.reset();
+        verify(orig, times(2)).isCommitted();
+        verify(orig, times(1)).reset();
+        Mockito.verifyNoMoreInteractions(orig);
+    }
+
     private String callTesteeAndGetLogMessage(String[] logMessages) {
         final SlingHttpServletResponse orig = Mockito.mock(SlingHttpServletResponse.class);
         final RequestData requestData = mock(RequestData.class);
@@ -136,28 +158,6 @@ public class SlingHttpServletResponseImplTest {
         // validate that the log message is cut off and only the last MAX_NR_OF_MESSAGES
         // remain in the log message, check for the cut message
         assertTrue(logMessage.contains("... cut 504 messages ..."));
-    }
-
-    @Test
-    public void testReset() {
-        final SlingHttpServletResponse orig = mock(SlingHttpServletResponse.class);
-        final RequestData requestData = mock(RequestData.class);
-        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
-        when(requestData.getDispatchingInfo()).thenReturn(info);
-        info.setProtectHeadersOnInclude(true);
-
-        final HttpServletResponse include = new SlingHttpServletResponseImpl(requestData, orig);
-
-        when(orig.isCommitted()).thenReturn(false);
-        include.reset();
-        verify(orig, times(1)).isCommitted();
-        Mockito.verifyNoMoreInteractions(orig);
-
-        when(orig.isCommitted()).thenReturn(true);
-        include.reset();
-        verify(orig, times(2)).isCommitted();
-        verify(orig, times(1)).reset();
-        Mockito.verifyNoMoreInteractions(orig);
     }
 
     @Test

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -86,97 +86,7 @@ public class SlingHttpServletResponseImplTest {
         "4749 LOG Adding bindings took 4 microseconds"
     };
 
-    @Test
-    public void testRecursiveCalls() {
-        String[] recursivePartStrings = {
-            "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
-            "3757 LOG Calling filter: org.apache.sling.i18n.impl.I18NFilter",
-            "4859 TIMER_END{135,/libs/slingshot/Component/head.html.jsp#1}",
-            "3765 LOG Calling filter: org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter",
-            "2678 TIMER_START{ServletResolution}",
-            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-            "2678 TIMER_START{ServletResolution}",
-            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-            "3774 LOG Applying Componentfilters",
-            "3797 TIMER_START{/libs/slingshot/Home/html.jsp#0}",
-            "3946 LOG Adding bindings took 18 microseconds",
-            "4405 LOG Including resource JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot (SlingRequestPathInfo: path='/content/slingshot', selectorString='head', extension='html', suffix='null')",
-            "4414 TIMER_START{resolveServlet(/content/slingshot)}",
-            "4670 TIMER_END{253,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Component/head.html.jsp",
-            "4673 LOG Applying Includefilters"
-        };
-
-// build a string array which resembles the log of recursive includes (50 levels deep)
-        String[] concatenatedArray = Stream.concat(Arrays.stream(logMessages), Arrays.stream(recursivePartStrings))
-                .toArray(String[]::new);
-        for (int i = 0; i < 50; i++) {
-            concatenatedArray = Stream.concat(Arrays.stream(concatenatedArray), Arrays.stream(recursivePartStrings))
-                    .toArray(String[]::new);
-        }
-
-        final SlingHttpServletResponse orig = Mockito.mock(SlingHttpServletResponse.class);
-        final RequestData requestData = mock(RequestData.class);
-        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
-        final RequestProgressTracker requestProgressTracker = mock(RequestProgressTracker.class);
-        when(requestData.getDispatchingInfo()).thenReturn(info);
-        when(requestData.getRequestProgressTracker()).thenReturn(requestProgressTracker);
-        when(requestData.getActiveServletName()).thenReturn(ACTIVE_SERVLET_NAME);
-
-        ArrayList<String> logMessagesList = new ArrayList<>(Arrays.asList(concatenatedArray));
-        when(requestProgressTracker.getMessages()).thenAnswer(invocation -> logMessagesList.iterator());
-        info.setProtectHeadersOnInclude(true);
-
-        final HttpServletResponse include = new SlingHttpServletResponseImpl(requestData, orig);
-
-        include.setContentLength(54);
-        include.setContentLengthLong(33L);
-        include.setContentType("text/plain");
-        include.setLocale(null);
-        include.setBufferSize(4500);
-
-        Mockito.verify(orig, never()).setContentLength(54);
-        Mockito.verify(orig, never()).setContentLengthLong(33L);
-        Mockito.verify(orig, never()).setContentType("text/plain");
-        Mockito.verify(orig, never()).setLocale(null);
-        Mockito.verify(orig, never()).setBufferSize(4500);
-
-        ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String.class);
-        verify(requestProgressTracker, times(1)).log(logCaptor.capture());
-        String logMessage = logCaptor.getValue();
-
-        // validate that the log message is cut off and only the last MAX_NR_OF_MESSAGES
-        // remain in the log message, check for the cut message
-        assertTrue(logMessage.contains("... cut"));
-    }
-
-    @Test
-    public void testReset() {
-        final SlingHttpServletResponse orig = mock(SlingHttpServletResponse.class);
-        final RequestData requestData = mock(RequestData.class);
-        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
-        when(requestData.getDispatchingInfo()).thenReturn(info);
-        info.setProtectHeadersOnInclude(true);
-
-        final HttpServletResponse include = new SlingHttpServletResponseImpl(requestData, orig);
-
-        when(orig.isCommitted()).thenReturn(false);
-        include.reset();
-        verify(orig, times(1)).isCommitted();
-        Mockito.verifyNoMoreInteractions(orig);
-
-        when(orig.isCommitted()).thenReturn(true);
-        include.reset();
-        verify(orig, times(2)).isCommitted();
-        verify(orig, times(1)).reset();
-        Mockito.verifyNoMoreInteractions(orig);
-    }
-
-    @Test
-    public void testContentMethods() {
+    private String callTesteeAndGetLogMessage(String[] logMessages) {
         final SlingHttpServletResponse orig = Mockito.mock(SlingHttpServletResponse.class);
         final RequestData requestData = mock(RequestData.class);
         final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
@@ -205,7 +115,54 @@ public class SlingHttpServletResponseImplTest {
 
         ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String.class);
         verify(requestProgressTracker, times(1)).log(logCaptor.capture());
-        String logMessage = logCaptor.getValue();
+        return logCaptor.getValue();
+    }
+
+    @Test
+    public void testRecursiveCalls() {
+
+        // build a string array which resembles the log of recursive includes (50 levels
+        // deep)
+        String[] recursivePartStrings = Arrays.copyOfRange(logMessages, 14, logMessages.length - 2);
+        String[] concatenatedArray = Stream.concat(Arrays.stream(logMessages), Arrays.stream(recursivePartStrings))
+                .toArray(String[]::new);
+        for (int i = 0; i < 50; i++) {
+            concatenatedArray = Stream.concat(Arrays.stream(concatenatedArray), Arrays.stream(recursivePartStrings))
+                    .toArray(String[]::new);
+        }
+
+        String logMessage = callTesteeAndGetLogMessage(concatenatedArray);
+
+        // validate that the log message is cut off and only the last MAX_NR_OF_MESSAGES
+        // remain in the log message, check for the cut message
+        assertTrue(logMessage.contains("... cut 504 messages ..."));
+    }
+
+    @Test
+    public void testReset() {
+        final SlingHttpServletResponse orig = mock(SlingHttpServletResponse.class);
+        final RequestData requestData = mock(RequestData.class);
+        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
+        when(requestData.getDispatchingInfo()).thenReturn(info);
+        info.setProtectHeadersOnInclude(true);
+
+        final HttpServletResponse include = new SlingHttpServletResponseImpl(requestData, orig);
+
+        when(orig.isCommitted()).thenReturn(false);
+        include.reset();
+        verify(orig, times(1)).isCommitted();
+        Mockito.verifyNoMoreInteractions(orig);
+
+        when(orig.isCommitted()).thenReturn(true);
+        include.reset();
+        verify(orig, times(2)).isCommitted();
+        verify(orig, times(1)).reset();
+        Mockito.verifyNoMoreInteractions(orig);
+    }
+
+    @Test
+    public void testContentMethods() {
+        String logMessage = callTesteeAndGetLogMessage(logMessages);
         assertEquals(
                 String.format(
                         "ERROR: Servlet %s tried to override the 'Content-Type' header from 'null' to 'text/plain'. This is a violation of the RequestDispatcher.include() contract - https://jakarta.ee/specifications/servlet/4.0/apidocs/javax/servlet/requestdispatcher#include-javax.servlet.ServletRequest-javax.servlet.ServletResponse-. , Include stack: /libs/slingshot/Component/head.html.jsp#1 -> /libs/slingshot/Home/html.jsp#0. All RequestProgressTracker messages: %s",


### PR DESCRIPTION
on excessive recursions, the potential origins may blow up with OOM error. If there's more than 500 entries, use the last 500 entries only.