### PR TITLE
SLING-12697 do not check for violations when the response is commited…

### DIFF
--- a/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
@@ -325,7 +325,7 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
 
     @Override
     public void setContentType(final String type) {
-        if (!isInclude()) {
+        if (super.getResponse().isCommitted() || !isInclude()) {
             super.setContentType(type);
         } else {
             Optional<String> message = checkContentTypeOverride(type);
@@ -358,7 +358,7 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
      * @param contentType the 'Content-Type' value that is being set
      * @return an optional message to log
      */
-    private Optional<String> checkContentTypeOverride(@Nullable String contentType) {
+    protected Optional<String> checkContentTypeOverride(@Nullable String contentType) {
         if (requestData.getSlingRequestProcessor().getContentTypeHeaderState() == ContentTypeHeaderState.VIOLATED) {
             // return immediatly as the content type header has already been violated
             // prevoiously, no more checks needed

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -88,6 +88,24 @@ public class SlingHttpServletResponseImplTest {
     };
 
     @Test
+    public void testNoViolationChecksOnCommitedResponse() throws IOException {
+        final SlingHttpServletResponse orig = Mockito.mock(SlingHttpServletResponse.class);
+        Mockito.when(orig.isCommitted()).thenReturn(true);
+
+        final RequestData requestData = mock(RequestData.class);
+        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
+        when(requestData.getDispatchingInfo()).thenReturn(info);
+        info.setProtectHeadersOnInclude(true);
+
+        final SlingHttpServletResponseImpl include = new SlingHttpServletResponseImpl(requestData, orig);
+        SlingHttpServletResponseImpl spyInclude = Mockito.spy(include);
+
+        spyInclude.setContentType("someOtherType");
+        Mockito.verify(orig, times(1)).setContentType(Mockito.any());
+        Mockito.verify(spyInclude, never()).checkContentTypeOverride(Mockito.any());
+    }
+
+    @Test
     public void testReset() {
         final SlingHttpServletResponse orig = mock(SlingHttpServletResponse.class);
         final RequestData requestData = mock(RequestData.class);

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -88,7 +88,7 @@ public class SlingHttpServletResponseImplTest {
     };
 
     @Test
-    public void testNoViolationChecksOnCommitedResponse() throws IOException {
+    public void testNoViolationChecksOnCommitedResponse() {
         final SlingHttpServletResponse orig = Mockito.mock(SlingHttpServletResponse.class);
         Mockito.when(orig.isCommitted()).thenReturn(true);
 


### PR DESCRIPTION
… as the content type header change will be ignored according to the servlet api specification - avoid false positives