### PR TITLE
SLING-12801 - Error handler does not reset the response during include

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,15 @@
             <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- needed to mock final methods-->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.6.1</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.jmock</groupId>
             <artifactId>jmock-junit4</artifactId>

--- a/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
@@ -228,8 +228,10 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
         if (!this.isProtectHeadersOnInclude() || isError()) {
             super.reset();
         } else {
-            // ignore if not committed
-            if (super.isCommitted()) {
+            // ignore if not committed: because we want the exception to be thrown when the
+            // response is committed. but we do not want to call reset when the headers
+            // should be protected, as this would reset them as well
+            if (this.isCommitted()) {
                 super.reset();
             }
         }
@@ -330,7 +332,7 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
 
     @Override
     public void setContentType(final String type) {
-        if (super.isCommitted() || !isInclude()) {
+        if (this.isCommitted() || !isInclude()) {
             super.setContentType(type);
         } else {
             Optional<String> message = checkContentTypeOverride(type);

--- a/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
@@ -90,7 +90,7 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
         }
     }
 
-    protected final RequestData getRequestData() {
+    public final RequestData getRequestData() {
         return requestData;
     }
 
@@ -166,6 +166,11 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
                 && this.requestData.getDispatchingInfo().getType() == javax.servlet.DispatcherType.INCLUDE;
     }
 
+    private boolean isError() {
+        return this.requestData.getDispatchingInfo() != null
+                && this.requestData.getDispatchingInfo().getType() == javax.servlet.DispatcherType.ERROR;
+    }
+
     private boolean isProtectHeadersOnInclude() {
         return this.requestData.getDispatchingInfo() != null
                 && this.requestData.getDispatchingInfo().isProtectHeadersOnInclude();
@@ -220,12 +225,12 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
 
     @Override
     public void reset() {
-        if (!this.isProtectHeadersOnInclude()) {
+        if (!this.isProtectHeadersOnInclude() || isError()) {
             super.reset();
         } else {
             // ignore if not committed
-            if (getResponse().isCommitted()) {
-                getResponse().reset();
+            if (super.isCommitted()) {
+                super.reset();
             }
         }
     }
@@ -325,7 +330,7 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
 
     @Override
     public void setContentType(final String type) {
-        if (super.getResponse().isCommitted() || !isInclude()) {
+        if (super.isCommitted() || !isInclude()) {
             super.setContentType(type);
         } else {
             Optional<String> message = checkContentTypeOverride(type);

--- a/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
@@ -138,14 +138,17 @@ public class ErrorFilterChain extends AbstractSlingFilterChain {
                     final DispatchingInfo dispatchInfo = new DispatchingInfo(DispatcherType.ERROR);
                     slingResponse.getRequestData().setDispatchingInfo(dispatchInfo);
                     response.reset();
+                    super.doFilter(request, response);
                 } finally {
                     slingResponse.getRequestData().setDispatchingInfo(originalInfo);
                 }
             } else {
                 response.reset();
+                super.doFilter(request, response);
             }
+        } else {
+            super.doFilter(request, response);
         }
-        super.doFilter(request, response);
     }
 
     protected void render(final SlingHttpServletRequest request, final SlingHttpServletResponse response)

--- a/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
@@ -120,12 +120,30 @@ public class ErrorFilterChain extends AbstractSlingFilterChain {
                 }
                 return;
             }
+
             // reset the response to clear headers and body
             if (response instanceof SlingHttpServletResponseImpl) {
-                final DispatchingInfo dispatchInfo = new DispatchingInfo(DispatcherType.ERROR);
-                ((SlingHttpServletResponseImpl) response).getRequestData().setDispatchingInfo(dispatchInfo);
+                SlingHttpServletResponseImpl slingResponse = (SlingHttpServletResponseImpl) response;
+                /*
+                 * Below section stores the original dispatching info for later restoration.
+                 * This is necessary to ensure that the dispatching info is set to ERROR
+                 * while the error is being handled and the response is reset, but restored to
+                 * its original state after the error handling is complete. This is important
+                 * for correct request processing and to avoid side effects on subsequent
+                 * filters or request processing steps.
+                 */
+                DispatchingInfo originalInfo = null;
+                try {
+                    originalInfo = slingResponse.getRequestData().getDispatchingInfo();
+                    final DispatchingInfo dispatchInfo = new DispatchingInfo(DispatcherType.ERROR);
+                    slingResponse.getRequestData().setDispatchingInfo(dispatchInfo);
+                    response.reset();
+                } finally {
+                    slingResponse.getRequestData().setDispatchingInfo(originalInfo);
+                }
+            } else {
+                response.reset();
             }
-            response.reset();
         }
         super.doFilter(request, response);
     }

--- a/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.engine.impl.filter;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -27,6 +28,8 @@ import java.io.IOException;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.ErrorHandler;
+import org.apache.sling.engine.impl.SlingHttpServletResponseImpl;
+import org.apache.sling.engine.impl.request.DispatchingInfo;
 
 public class ErrorFilterChain extends AbstractSlingFilterChain {
 
@@ -118,6 +121,10 @@ public class ErrorFilterChain extends AbstractSlingFilterChain {
                 return;
             }
             // reset the response to clear headers and body
+            if (response instanceof SlingHttpServletResponseImpl) {
+                final DispatchingInfo dispatchInfo = new DispatchingInfo(DispatcherType.ERROR);
+                ((SlingHttpServletResponseImpl) response).getRequestData().setDispatchingInfo(dispatchInfo);
+            }
             response.reset();
         }
         super.doFilter(request, response);

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -107,24 +107,33 @@ public class SlingHttpServletResponseImplTest {
 
     @Test
     public void testReset() {
-        final SlingHttpServletResponse orig = mock(SlingHttpServletResponse.class);
+        final SlingHttpServletResponse originalResponse = mock(SlingHttpServletResponse.class);
         final RequestData requestData = mock(RequestData.class);
-        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
-        when(requestData.getDispatchingInfo()).thenReturn(info);
-        info.setProtectHeadersOnInclude(true);
+        DispatchingInfo dispatchingInfo = new DispatchingInfo(DispatcherType.INCLUDE);
+        when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
+        dispatchingInfo.setProtectHeadersOnInclude(true);
 
-        final HttpServletResponse include = new SlingHttpServletResponseImpl(requestData, orig);
+        final HttpServletResponse includeResponse = new SlingHttpServletResponseImpl(requestData, originalResponse);
 
-        when(orig.isCommitted()).thenReturn(false);
-        include.reset();
-        verify(orig, times(1)).isCommitted();
-        Mockito.verifyNoMoreInteractions(orig);
+        when(originalResponse.isCommitted()).thenReturn(false);
+        includeResponse.reset();
+        verify(originalResponse, times(1)).isCommitted();
+        Mockito.verifyNoMoreInteractions(originalResponse);
 
-        when(orig.isCommitted()).thenReturn(true);
-        include.reset();
-        verify(orig, times(2)).isCommitted();
-        verify(orig, times(1)).reset();
-        Mockito.verifyNoMoreInteractions(orig);
+        when(originalResponse.isCommitted()).thenReturn(true);
+        includeResponse.reset();
+        verify(originalResponse, times(2)).isCommitted();
+        verify(originalResponse, times(1)).reset();
+        Mockito.verifyNoMoreInteractions(originalResponse);
+
+        // check if reset is called on error handling
+        dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
+        when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
+        dispatchingInfo.setProtectHeadersOnInclude(true);
+        when(originalResponse.isCommitted()).thenReturn(false);
+        includeResponse.reset();
+        verify(originalResponse, times(2)).reset();
+        Mockito.verifyNoMoreInteractions(originalResponse);
     }
 
     private String callTesteeAndGetRequestProgressTrackerMessage(String[] logMessages) {

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -125,14 +125,22 @@ public class SlingHttpServletResponseImplTest {
         verify(originalResponse, times(2)).isCommitted();
         verify(originalResponse, times(1)).reset();
         Mockito.verifyNoMoreInteractions(originalResponse);
+    }
 
-        // check if reset is called on error handling
-        dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
-        when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
+    @Test
+    public void testResetOnError() {
+        final SlingHttpServletResponse originalResponse = mock(SlingHttpServletResponse.class);
+        final RequestData requestData = mock(RequestData.class);
+
+        // Simulate an error dispatching scenario on a uncommitted response
+        DispatchingInfo dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
+        final HttpServletResponse includeResponse = new SlingHttpServletResponseImpl(requestData, originalResponse);
         dispatchingInfo.setProtectHeadersOnInclude(true);
+        when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
         when(originalResponse.isCommitted()).thenReturn(false);
+
         includeResponse.reset();
-        verify(originalResponse, times(2)).reset();
+        verify(originalResponse, times(1)).reset();
         Mockito.verifyNoMoreInteractions(originalResponse);
     }
 

--- a/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
@@ -101,7 +101,13 @@ public class ErrorFilterChainTest {
         final ErrorFilterChain chain2 = new ErrorFilterChain(new FilterHandle[0], handler, 404, "not found");
         chain2.doFilter(request, response);
         verify(response, times(1)).reset();
+
+        // called ones with thew error dispatcher info
         verify(requestData, times(1))
-                .setDispatchingInfo(Mockito.argThat(info -> info.getType() == DispatcherType.ERROR));
+                .setDispatchingInfo(Mockito.argThat(info -> info != null && info.getType() == DispatcherType.ERROR));
+
+        // called once with the original request dispatcher info that is restored after
+        // the error handling, in this case null
+        verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(info -> info == null));
     }
 }

--- a/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
@@ -22,6 +22,7 @@ import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -108,6 +109,6 @@ public class ErrorFilterChainTest {
 
         // ensure that the original request dispatcher info that is restored after the
         // error handling was performed, in this case null
-        verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(info -> info == null));
+        verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(Objects::isNull));
     }
 }

--- a/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
@@ -102,12 +102,12 @@ public class ErrorFilterChainTest {
         chain2.doFilter(request, response);
         verify(response, times(1)).reset();
 
-        // called ones with thew error dispatcher info
+        // ensure that the dispatching info of type ERROR is set on the request data
         verify(requestData, times(1))
                 .setDispatchingInfo(Mockito.argThat(info -> info != null && info.getType() == DispatcherType.ERROR));
 
-        // called once with the original request dispatcher info that is restored after
-        // the error handling, in this case null
+        // ensure that the original request dispatcher info that is restored after the
+        // error handling was performed, in this case null
         verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(info -> info == null));
     }
 }


### PR DESCRIPTION
…tion checks are enabled

Setting a dispatching info of type error to indicate the error flow so that this can be respected during reset
@cziegeler @raducotescu 