### PR TITLE
SLING-12801 - Error handler does not reset the response during include (to master)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,15 @@
             <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- needed to mock final methods-->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.6.1</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.jmock</groupId>
             <artifactId>jmock-junit4</artifactId>

--- a/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
@@ -202,8 +202,10 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
         if (!this.isProtectHeadersOnInclude() || isError()) {
             super.reset();
         } else {
-            // ignore if not committed
-            if (super.isCommitted()) {
+            // ignore if not committed: because we want the exception to be thrown when the
+            // response is committed. but we do not want to call reset when the headers
+            // should be protected, as this would reset them as well
+            if (this.isCommitted()) {
                 super.reset();
             }
         }
@@ -304,7 +306,7 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
 
     @Override
     public void setContentType(final String type) {
-        if (super.isCommitted() || !isInclude()) {
+        if (this.isCommitted() || !isInclude()) {
             super.setContentType(type);
         } else {
             Optional<String> message = checkContentTypeOverride(type);

--- a/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
@@ -156,7 +156,7 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
 
     private boolean isError() {
         return this.requestData.getDispatchingInfo() != null
-                && this.requestData.getDispatchingInfo().getType() == javax.servlet.DispatcherType.ERROR;
+                && this.requestData.getDispatchingInfo().getType() == jakarta.servlet.DispatcherType.ERROR;
     }
 
     private boolean isProtectHeadersOnInclude() {
@@ -445,7 +445,7 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
      * include.
      *
      * @param currentContentType the current 'Content-Type' header
-     * @param setContentType the 'Content-Type' header that is being set
+     * @param setContentType     the 'Content-Type' header that is being set
      */
     private String getMessage(@Nullable String currentContentType, @Nullable String setContentType) {
         String unmatchedStartTimers = findUnmatchedTimerStarts();

--- a/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
@@ -90,7 +90,7 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
         }
     }
 
-    protected final RequestData getRequestData() {
+    public final RequestData getRequestData() {
         return requestData;
     }
 
@@ -154,6 +154,11 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
                 && this.requestData.getDispatchingInfo().getType() == jakarta.servlet.DispatcherType.INCLUDE;
     }
 
+    private boolean isError() {
+        return this.requestData.getDispatchingInfo() != null
+                && this.requestData.getDispatchingInfo().getType() == javax.servlet.DispatcherType.ERROR;
+    }
+
     private boolean isProtectHeadersOnInclude() {
         return this.requestData.getDispatchingInfo() != null
                 && this.requestData.getDispatchingInfo().isProtectHeadersOnInclude();
@@ -194,12 +199,12 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
 
     @Override
     public void reset() {
-        if (!this.isProtectHeadersOnInclude()) {
+        if (!this.isProtectHeadersOnInclude() || isError()) {
             super.reset();
         } else {
             // ignore if not committed
-            if (getResponse().isCommitted()) {
-                getResponse().reset();
+            if (super.isCommitted()) {
+                super.reset();
             }
         }
     }
@@ -299,7 +304,7 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
 
     @Override
     public void setContentType(final String type) {
-        if (super.getResponse().isCommitted() || !isInclude()) {
+        if (super.isCommitted() || !isInclude()) {
             super.setContentType(type);
         } else {
             Optional<String> message = checkContentTypeOverride(type);

--- a/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
@@ -137,14 +137,17 @@ public class ErrorFilterChain extends AbstractSlingFilterChain {
                     final DispatchingInfo dispatchInfo = new DispatchingInfo(DispatcherType.ERROR);
                     slingResponse.getRequestData().setDispatchingInfo(dispatchInfo);
                     response.reset();
+                    super.doFilter(request, response);
                 } finally {
                     slingResponse.getRequestData().setDispatchingInfo(originalInfo);
                 }
             } else {
                 response.reset();
+                super.doFilter(request, response);
             }
+        } else {
+            super.doFilter(request, response);
         }
-        super.doFilter(request, response);
     }
 
     protected void render(final SlingJakartaHttpServletRequest request, final SlingJakartaHttpServletResponse response)

--- a/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
@@ -20,6 +20,7 @@ package org.apache.sling.engine.impl.filter;
 
 import java.io.IOException;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;

--- a/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
@@ -120,6 +120,10 @@ public class ErrorFilterChain extends AbstractSlingFilterChain {
                 return;
             }
             // reset the response to clear headers and body
+            if (response instanceof SlingHttpServletResponseImpl) {
+                final DispatchingInfo dispatchInfo = new DispatchingInfo(DispatcherType.ERROR);
+                ((SlingHttpServletResponseImpl) response).getRequestData().setDispatchingInfo(dispatchInfo);
+            }
             response.reset();
         }
         super.doFilter(request, response);

--- a/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
+++ b/src/main/java/org/apache/sling/engine/impl/filter/ErrorFilterChain.java
@@ -26,6 +26,8 @@ import jakarta.servlet.ServletResponse;
 import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.servlets.JakartaErrorHandler;
+import org.apache.sling.engine.impl.SlingJakartaHttpServletResponseImpl;
+import org.apache.sling.engine.impl.request.DispatchingInfo;
 
 public class ErrorFilterChain extends AbstractSlingFilterChain {
 
@@ -121,8 +123,8 @@ public class ErrorFilterChain extends AbstractSlingFilterChain {
             }
 
             // reset the response to clear headers and body
-            if (response instanceof SlingHttpServletResponseImpl) {
-                SlingHttpServletResponseImpl slingResponse = (SlingHttpServletResponseImpl) response;
+            if (response instanceof SlingJakartaHttpServletResponseImpl) {
+                SlingJakartaHttpServletResponseImpl slingResponse = (SlingJakartaHttpServletResponseImpl) response;
                 /*
                  * Below section stores the original dispatching info for later restoration.
                  * This is necessary to ensure that the dispatching info is set to ERROR

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -49,41 +49,41 @@ public class SlingHttpServletResponseImplTest {
 
     private static final String ACTIVE_SERVLET_NAME = "activeServlet";
     String[] logMessages = {
-            "0 TIMER_START{Request Processing}",
-            "6 COMMENT timer_end format is {<elapsed microseconds>,<timer name>} <optional message>",
-            "17 LOG Method=GET, PathInfo=null",
-            "20 TIMER_START{handleSecurity}",
-            "2104 TIMER_END{2081,handleSecurity} authenticator org.apache.sling.auth.core.impl.SlingAuthenticator@6367091e returns true",
-            "2478 TIMER_START{ResourceResolution}",
-            "2668 TIMER_END{189,ResourceResolution} URI=/content/slingshot.html resolves to Resource=JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot",
-            "2678 LOG Resource Path Info: SlingRequestPathInfo: path='/content/slingshot', selectorString='null', extension='html', suffix='null'",
-            "2678 TIMER_START{ServletResolution}",
-            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-            "3736 LOG Applying REQUESTfilters",
-            "3751 LOG Calling filter: com.composum.sling.nodes.mount.remote.RemoteRequestFilter",
-            "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
-            "3757 LOG Calling filter: org.apache.sling.i18n.impl.I18NFilter",
-            "4859 TIMER_END{135,/libs/slingshot/Component/head.html.jsp#1}",
-            "3765 LOG Calling filter: org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter",
-            "2678 TIMER_START{ServletResolution}",
-            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-            "2678 TIMER_START{ServletResolution}",
-            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-            "3774 LOG Applying Componentfilters",
-            "3797 TIMER_START{/libs/slingshot/Home/html.jsp#0}",
-            "3946 LOG Adding bindings took 18 microseconds",
-            "4405 LOG Including resource JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot (SlingRequestPathInfo: path='/content/slingshot', selectorString='head', extension='html', suffix='null')",
-            "4414 TIMER_START{resolveServlet(/content/slingshot)}",
-            "4670 TIMER_END{253,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Component/head.html.jsp",
-            "4673 LOG Applying Includefilters",
-            "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
-            "4749 LOG Adding bindings took 4 microseconds"
+        "0 TIMER_START{Request Processing}",
+        "6 COMMENT timer_end format is {<elapsed microseconds>,<timer name>} <optional message>",
+        "17 LOG Method=GET, PathInfo=null",
+        "20 TIMER_START{handleSecurity}",
+        "2104 TIMER_END{2081,handleSecurity} authenticator org.apache.sling.auth.core.impl.SlingAuthenticator@6367091e returns true",
+        "2478 TIMER_START{ResourceResolution}",
+        "2668 TIMER_END{189,ResourceResolution} URI=/content/slingshot.html resolves to Resource=JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot",
+        "2678 LOG Resource Path Info: SlingRequestPathInfo: path='/content/slingshot', selectorString='null', extension='html', suffix='null'",
+        "2678 TIMER_START{ServletResolution}",
+        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+        "3736 LOG Applying REQUESTfilters",
+        "3751 LOG Calling filter: com.composum.sling.nodes.mount.remote.RemoteRequestFilter",
+        "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
+        "3757 LOG Calling filter: org.apache.sling.i18n.impl.I18NFilter",
+        "4859 TIMER_END{135,/libs/slingshot/Component/head.html.jsp#1}",
+        "3765 LOG Calling filter: org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter",
+        "2678 TIMER_START{ServletResolution}",
+        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+        "2678 TIMER_START{ServletResolution}",
+        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+        "3774 LOG Applying Componentfilters",
+        "3797 TIMER_START{/libs/slingshot/Home/html.jsp#0}",
+        "3946 LOG Adding bindings took 18 microseconds",
+        "4405 LOG Including resource JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot (SlingRequestPathInfo: path='/content/slingshot', selectorString='head', extension='html', suffix='null')",
+        "4414 TIMER_START{resolveServlet(/content/slingshot)}",
+        "4670 TIMER_END{253,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Component/head.html.jsp",
+        "4673 LOG Applying Includefilters",
+        "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
+        "4749 LOG Adding bindings took 4 microseconds"
     };
 
     @Test
@@ -106,13 +106,14 @@ public class SlingHttpServletResponseImplTest {
 
     @Test
     public void testReset() {
-        final SlingJakartaHttpServletResponse orig = mock(SlingJakartaHttpServletResponse.class);
+        final SlingJakartaHttpServletResponse originalResponse = mock(SlingJakartaHttpServletResponse.class);
         final RequestData requestData = mock(RequestData.class);
         DispatchingInfo dispatchingInfo = new DispatchingInfo(DispatcherType.INCLUDE);
         when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
         dispatchingInfo.setProtectHeadersOnInclude(true);
 
-        final HttpServletResponse include = new SlingJakartaHttpServletResponseImpl(requestData, orig);
+        final HttpServletResponse includeResponse =
+                new SlingJakartaHttpServletResponseImpl(requestData, originalResponse);
 
         when(originalResponse.isCommitted()).thenReturn(false);
         includeResponse.reset();
@@ -133,8 +134,8 @@ public class SlingHttpServletResponseImplTest {
 
         // Simulate an error dispatching scenario on a uncommitted response
         DispatchingInfo dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
-        final HttpServletResponse includeResponse = new SlingJakartaHttpServletResponseImpl(requestData,
-                originalResponse);
+        final HttpServletResponse includeResponse =
+                new SlingJakartaHttpServletResponseImpl(requestData, originalResponse);
         dispatchingInfo.setProtectHeadersOnInclude(true);
         when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
         when(originalResponse.isCommitted()).thenReturn(false);
@@ -148,8 +149,8 @@ public class SlingHttpServletResponseImplTest {
     private String callTesteeAndGetRequestProgressTrackerMessage(String[] logMessages) {
         final SlingJakartaHttpServletResponse orig = Mockito.mock(SlingJakartaHttpServletResponse.class);
         final RequestData requestData = mock(RequestData.class);
-        final DispatchingInfo info = new Dispatchin questProgressTracker requestProgressTracker = mock(R
-                questProgressTracker.class);
+        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
+        final RequestProgressTracker requestProgressTracker = mock(RequestProgressTracker.class);
         when(requestData.getDispatchingInfo()).thenReturn(info);
         when(requestData.getRequestProgressTracker()).thenReturn(requestProgressTracker);
         when(requestData.getActiveServletName()).thenReturn(ACTIVE_SERVLET_NAME);

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -49,41 +49,41 @@ public class SlingHttpServletResponseImplTest {
 
     private static final String ACTIVE_SERVLET_NAME = "activeServlet";
     String[] logMessages = {
-        "0 TIMER_START{Request Processing}",
-        "6 COMMENT timer_end format is {<elapsed microseconds>,<timer name>} <optional message>",
-        "17 LOG Method=GET, PathInfo=null",
-        "20 TIMER_START{handleSecurity}",
-        "2104 TIMER_END{2081,handleSecurity} authenticator org.apache.sling.auth.core.impl.SlingAuthenticator@6367091e returns true",
-        "2478 TIMER_START{ResourceResolution}",
-        "2668 TIMER_END{189,ResourceResolution} URI=/content/slingshot.html resolves to Resource=JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot",
-        "2678 LOG Resource Path Info: SlingRequestPathInfo: path='/content/slingshot', selectorString='null', extension='html', suffix='null'",
-        "2678 TIMER_START{ServletResolution}",
-        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-        "3736 LOG Applying REQUESTfilters",
-        "3751 LOG Calling filter: com.composum.sling.nodes.mount.remote.RemoteRequestFilter",
-        "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
-        "3757 LOG Calling filter: org.apache.sling.i18n.impl.I18NFilter",
-        "4859 TIMER_END{135,/libs/slingshot/Component/head.html.jsp#1}",
-        "3765 LOG Calling filter: org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter",
-        "2678 TIMER_START{ServletResolution}",
-        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-        "2678 TIMER_START{ServletResolution}",
-        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-        "3774 LOG Applying Componentfilters",
-        "3797 TIMER_START{/libs/slingshot/Home/html.jsp#0}",
-        "3946 LOG Adding bindings took 18 microseconds",
-        "4405 LOG Including resource JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot (SlingRequestPathInfo: path='/content/slingshot', selectorString='head', extension='html', suffix='null')",
-        "4414 TIMER_START{resolveServlet(/content/slingshot)}",
-        "4670 TIMER_END{253,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Component/head.html.jsp",
-        "4673 LOG Applying Includefilters",
-        "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
-        "4749 LOG Adding bindings took 4 microseconds"
+            "0 TIMER_START{Request Processing}",
+            "6 COMMENT timer_end format is {<elapsed microseconds>,<timer name>} <optional message>",
+            "17 LOG Method=GET, PathInfo=null",
+            "20 TIMER_START{handleSecurity}",
+            "2104 TIMER_END{2081,handleSecurity} authenticator org.apache.sling.auth.core.impl.SlingAuthenticator@6367091e returns true",
+            "2478 TIMER_START{ResourceResolution}",
+            "2668 TIMER_END{189,ResourceResolution} URI=/content/slingshot.html resolves to Resource=JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot",
+            "2678 LOG Resource Path Info: SlingRequestPathInfo: path='/content/slingshot', selectorString='null', extension='html', suffix='null'",
+            "2678 TIMER_START{ServletResolution}",
+            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+            "3736 LOG Applying REQUESTfilters",
+            "3751 LOG Calling filter: com.composum.sling.nodes.mount.remote.RemoteRequestFilter",
+            "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
+            "3757 LOG Calling filter: org.apache.sling.i18n.impl.I18NFilter",
+            "4859 TIMER_END{135,/libs/slingshot/Component/head.html.jsp#1}",
+            "3765 LOG Calling filter: org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter",
+            "2678 TIMER_START{ServletResolution}",
+            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+            "2678 TIMER_START{ServletResolution}",
+            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+            "3774 LOG Applying Componentfilters",
+            "3797 TIMER_START{/libs/slingshot/Home/html.jsp#0}",
+            "3946 LOG Adding bindings took 18 microseconds",
+            "4405 LOG Including resource JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot (SlingRequestPathInfo: path='/content/slingshot', selectorString='head', extension='html', suffix='null')",
+            "4414 TIMER_START{resolveServlet(/content/slingshot)}",
+            "4670 TIMER_END{253,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Component/head.html.jsp",
+            "4673 LOG Applying Includefilters",
+            "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
+            "4749 LOG Adding bindings took 4 microseconds"
     };
 
     @Test
@@ -108,22 +108,31 @@ public class SlingHttpServletResponseImplTest {
     public void testReset() {
         final SlingJakartaHttpServletResponse orig = mock(SlingJakartaHttpServletResponse.class);
         final RequestData requestData = mock(RequestData.class);
-        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
-        when(requestData.getDispatchingInfo()).thenReturn(info);
-        info.setProtectHeadersOnInclude(true);
+        DispatchingInfo dispatchingInfo = new DispatchingInfo(DispatcherType.INCLUDE);
+        when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
+        dispatchingInfo.setProtectHeadersOnInclude(true);
 
         final HttpServletResponse include = new SlingJakartaHttpServletResponseImpl(requestData, orig);
 
-        when(orig.isCommitted()).thenReturn(false);
-        include.reset();
-        verify(orig, times(1)).isCommitted();
-        Mockito.verifyNoMoreInteractions(orig);
+        when(originalResponse.isCommitted()).thenReturn(false);
+        includeResponse.reset();
+        verify(originalResponse, times(1)).isCommitted();
+        Mockito.verifyNoMoreInteractions(originalResponse);
 
-        when(orig.isCommitted()).thenReturn(true);
-        include.reset();
-        verify(orig, times(2)).isCommitted();
-        verify(orig, times(1)).reset();
-        Mockito.verifyNoMoreInteractions(orig);
+        when(originalResponse.isCommitted()).thenReturn(true);
+        includeResponse.reset();
+        verify(originalResponse, times(2)).isCommitted();
+        verify(originalResponse, times(1)).reset();
+        Mockito.verifyNoMoreInteractions(originalResponse);
+
+        // check if reset is called on error handling
+        dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
+        when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
+        dispatchingInfo.setProtectHeadersOnInclude(true);
+        when(originalResponse.isCommitted()).thenReturn(false);
+        includeResponse.reset();
+        verify(originalResponse, times(2)).reset();
+        Mockito.verifyNoMoreInteractions(originalResponse);
     }
 
     private String callTesteeAndGetRequestProgressTrackerMessage(String[] logMessages) {

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -124,14 +124,22 @@ public class SlingHttpServletResponseImplTest {
         verify(originalResponse, times(2)).isCommitted();
         verify(originalResponse, times(1)).reset();
         Mockito.verifyNoMoreInteractions(originalResponse);
+    }
 
-        // check if reset is called on error handling
-        dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
-        when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
+    @Test
+    public void testResetOnError() {
+        final SlingHttpServletResponse originalResponse = mock(SlingHttpServletResponse.class);
+        final RequestData requestData = mock(RequestData.class);
+
+        // Simulate an error dispatching scenario on a uncommitted response
+        DispatchingInfo dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
+        final HttpServletResponse includeResponse = new SlingHttpServletResponseImpl(requestData, originalResponse);
         dispatchingInfo.setProtectHeadersOnInclude(true);
+        when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
         when(originalResponse.isCommitted()).thenReturn(false);
+
         includeResponse.reset();
-        verify(originalResponse, times(2)).reset();
+        verify(originalResponse, times(1)).reset();
         Mockito.verifyNoMoreInteractions(originalResponse);
     }
 

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -128,26 +128,28 @@ public class SlingHttpServletResponseImplTest {
 
     @Test
     public void testResetOnError() {
-        final SlingHttpServletResponse originalResponse = mock(SlingHttpServletResponse.class);
+        final SlingJakartaHttpServletResponseImpl originalResponse = mock(SlingJakartaHttpServletResponseImpl.class);
         final RequestData requestData = mock(RequestData.class);
 
         // Simulate an error dispatching scenario on a uncommitted response
         DispatchingInfo dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
-        final HttpServletResponse includeResponse = new SlingHttpServletResponseImpl(requestData, originalResponse);
+        final HttpServletResponse includeResponse = new SlingJakartaHttpServletResponseImpl(requestData,
+                originalResponse);
         dispatchingInfo.setProtectHeadersOnInclude(true);
         when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
         when(originalResponse.isCommitted()).thenReturn(false);
 
         includeResponse.reset();
         verify(originalResponse, times(1)).reset();
+
         Mockito.verifyNoMoreInteractions(originalResponse);
     }
 
     private String callTesteeAndGetRequestProgressTrackerMessage(String[] logMessages) {
         final SlingJakartaHttpServletResponse orig = Mockito.mock(SlingJakartaHttpServletResponse.class);
         final RequestData requestData = mock(RequestData.class);
-        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
-        final RequestProgressTracker requestProgressTracker = mock(RequestProgressTracker.class);
+        final DispatchingInfo info = new Dispatchin questProgressTracker requestProgressTracker = mock(R
+                questProgressTracker.class);
         when(requestData.getDispatchingInfo()).thenReturn(info);
         when(requestData.getRequestProgressTracker()).thenReturn(requestProgressTracker);
         when(requestData.getActiveServletName()).thenReturn(ACTIVE_SERVLET_NAME);

--- a/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
@@ -100,12 +100,12 @@ public class ErrorFilterChainTest {
         chain2.doFilter(request, response);
         verify(response, times(1)).reset();
 
-        // called ones with thew error dispatcher info
+        // ensure that the dispatching info of type ERROR is set on the request data
         verify(requestData, times(1))
                 .setDispatchingInfo(Mockito.argThat(info -> info != null && info.getType() == DispatcherType.ERROR));
 
-        // called once with the original request dispatcher info that is restored after
-        // the error handling, in this case null
+        // ensure that the original request dispatcher info that is restored after the
+        // error handling was performed, in this case null
         verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(info -> info == null));
     }
 }

--- a/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
 public class ErrorFilterChainTest {
 
     @Test
-    public void testResponseCommitted() throws IOException, ServletException, jakarta.servlet.ServletException {
+    public void testResponseCommitted() throws IOException, jakarta.servlet.ServletException {
         final DefaultErrorHandler handler = new DefaultErrorHandler();
         final JakartaErrorHandler errorHandler = Mockito.mock(JakartaErrorHandler.class);
         handler.setDelegate(null, errorHandler);
@@ -67,7 +67,7 @@ public class ErrorFilterChainTest {
     }
 
     @Test
-    public void testResponseNotCommitted() throws IOException, ServletException, jakarta.servlet.ServletException {
+    public void testResponseNotCommitted() throws IOException, jakarta.servlet.ServletException {
         final DefaultErrorHandler handler = new DefaultErrorHandler();
         final JakartaErrorHandler errorHandler = Mockito.mock(JakartaErrorHandler.class);
         handler.setDelegate(null, errorHandler);
@@ -86,8 +86,7 @@ public class ErrorFilterChainTest {
     }
 
     @Test
-    public void testResponseDispatcherInfoOnError()
-            throws IOException, ServletException, jakarta.servlet.ServletException {
+    public void testResponseDispatcherInfoOnError() throws IOException, jakarta.servlet.ServletException {
         // mocks a final method in SlingJakartaHttpServletResponseImpl, needs
         // mockito-inline
         final DefaultErrorHandler handler = new DefaultErrorHandler();
@@ -110,9 +109,5 @@ public class ErrorFilterChainTest {
         // ensure that the original request dispatcher info that is restored after the
         // error handling was performed, in this case null
         verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(Objects::isNull));
-    }}
-
-    
-            
-
-    
+    }
+}

--- a/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
@@ -21,12 +21,12 @@ package org.apache.sling.engine.impl.filter;
 import java.io.IOException;
 import java.util.Objects;
 
-import jakarta.servlet.ServletException;
+import jakarta.servlet.DispatcherType;
 import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.servlets.JakartaErrorHandler;
 import org.apache.sling.engine.impl.DefaultErrorHandler;
-import org.apache.sling.engine.impl.SlingHttpServletResponseImpl;
+import org.apache.sling.engine.impl.SlingJakartaHttpServletResponseImpl;
 import org.apache.sling.engine.impl.request.RequestData;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
 public class ErrorFilterChainTest {
 
     @Test
-    public void testResponseCommitted() throws IOException, ServletException {
+    public void testResponseCommitted() throws IOException, ServletException, jakarta.servlet.ServletException {
         final DefaultErrorHandler handler = new DefaultErrorHandler();
         final JakartaErrorHandler errorHandler = Mockito.mock(JakartaErrorHandler.class);
         handler.setDelegate(null, errorHandler);
@@ -67,7 +67,7 @@ public class ErrorFilterChainTest {
     }
 
     @Test
-    public void testResponseNotCommitted() throws IOException, ServletException {
+    public void testResponseNotCommitted() throws IOException, ServletException, jakarta.servlet.ServletException {
         final DefaultErrorHandler handler = new DefaultErrorHandler();
         final JakartaErrorHandler errorHandler = Mockito.mock(JakartaErrorHandler.class);
         handler.setDelegate(null, errorHandler);
@@ -86,14 +86,16 @@ public class ErrorFilterChainTest {
     }
 
     @Test
-    public void testResponseDispatcherInfoOnError() throws IOException, ServletException {
-        // mocks a final method in SlingHttpServletResponseImpl, needs mockito-inline
+    public void testResponseDispatcherInfoOnError()
+            throws IOException, ServletException, jakarta.servlet.ServletException {
+        // mocks a final method in SlingJakartaHttpServletResponseImpl, needs
+        // mockito-inline
         final DefaultErrorHandler handler = new DefaultErrorHandler();
-        final ErrorHandler errorHandler = Mockito.mock(ErrorHandler.class);
-        handler.setDelegate(errorHandler);
+        final JakartaErrorHandler errorHandler = Mockito.mock(JakartaErrorHandler.class);
+        handler.setDelegate(null, errorHandler);
 
-        final SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
-        final SlingHttpServletResponseImpl response = Mockito.mock(SlingHttpServletResponseImpl.class);
+        final SlingJakartaHttpServletRequest request = Mockito.mock(SlingJakartaHttpServletRequest.class);
+        final SlingJakartaHttpServletResponseImpl response = Mockito.mock(SlingJakartaHttpServletResponseImpl.class);
         RequestData requestData = Mockito.mock(RequestData.class);
         when(response.getRequestData()).thenReturn(requestData);
 
@@ -108,5 +110,9 @@ public class ErrorFilterChainTest {
         // ensure that the original request dispatcher info that is restored after the
         // error handling was performed, in this case null
         verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(Objects::isNull));
-    }
-}
+    }}
+
+    
+            
+
+    

--- a/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
@@ -99,7 +99,13 @@ public class ErrorFilterChainTest {
         final ErrorFilterChain chain2 = new ErrorFilterChain(new FilterHandle[0], handler, 404, "not found");
         chain2.doFilter(request, response);
         verify(response, times(1)).reset();
+
+        // called ones with thew error dispatcher info
         verify(requestData, times(1))
-                .setDispatchingInfo(Mockito.argThat(info -> info.getType() == DispatcherType.ERROR));
+                .setDispatchingInfo(Mockito.argThat(info -> info != null && info.getType() == DispatcherType.ERROR));
+
+        // called once with the original request dispatcher info that is restored after
+        // the error handling, in this case null
+        verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(info -> info == null));
     }
 }

--- a/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.engine.impl.filter;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import jakarta.servlet.ServletException;
 import org.apache.sling.api.SlingJakartaHttpServletRequest;
@@ -106,6 +107,6 @@ public class ErrorFilterChainTest {
 
         // ensure that the original request dispatcher info that is restored after the
         // error handling was performed, in this case null
-        verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(info -> info == null));
+        verify(requestData, times(1)).setDispatchingInfo(Mockito.argThat(Objects::isNull));
     }
 }

--- a/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/filter/ErrorFilterChainTest.java
@@ -25,6 +25,8 @@ import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.servlets.JakartaErrorHandler;
 import org.apache.sling.engine.impl.DefaultErrorHandler;
+import org.apache.sling.engine.impl.SlingHttpServletResponseImpl;
+import org.apache.sling.engine.impl.request.RequestData;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -34,6 +36,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * This class tests the error filter chain in combination with the
@@ -78,5 +82,24 @@ public class ErrorFilterChainTest {
         final ErrorFilterChain chain2 = new ErrorFilterChain(new FilterHandle[0], handler, 500, "message");
         chain2.doFilter(request, response);
         Mockito.verify(errorHandler, times(1)).handleError(anyInt(), anyString(), eq(request), eq(response));
+    }
+
+    @Test
+    public void testResponseDispatcherInfoOnError() throws IOException, ServletException {
+        // mocks a final method in SlingHttpServletResponseImpl, needs mockito-inline
+        final DefaultErrorHandler handler = new DefaultErrorHandler();
+        final ErrorHandler errorHandler = Mockito.mock(ErrorHandler.class);
+        handler.setDelegate(errorHandler);
+
+        final SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
+        final SlingHttpServletResponseImpl response = Mockito.mock(SlingHttpServletResponseImpl.class);
+        RequestData requestData = Mockito.mock(RequestData.class);
+        when(response.getRequestData()).thenReturn(requestData);
+
+        final ErrorFilterChain chain2 = new ErrorFilterChain(new FilterHandle[0], handler, 404, "not found");
+        chain2.doFilter(request, response);
+        verify(response, times(1)).reset();
+        verify(requestData, times(1))
+                .setDispatchingInfo(Mockito.argThat(info -> info.getType() == DispatcherType.ERROR));
     }
 }


### PR DESCRIPTION
Setting a dispatching info of type error to indicate the error flow so that this can be respected during reset
@cziegeler