### PR TITLE
Fixes for SLING-12845 and SLING-12844

### DIFF
--- a/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingHttpServletResponseImpl.java
@@ -172,11 +172,17 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
     }
 
     private boolean isProtectHeadersOnInclude() {
+        // the dispatch info is null on the initial request, so it defaults to false for
+        // the initial request always, and therefore checks for the configuration set
+        // only for includes
         return this.requestData.getDispatchingInfo() != null
                 && this.requestData.getDispatchingInfo().isProtectHeadersOnInclude();
     }
 
     private boolean isCheckContentTypeOnInclude() {
+        // the dispatch info is null on the initial request, so it defaults to false for
+        // the initial request always, and therefore checks for the configuration set
+        // only for includes
         return this.requestData.getDispatchingInfo() != null
                 && this.requestData.getDispatchingInfo().isCheckContentTypeOnInclude();
     }
@@ -255,13 +261,6 @@ public class SlingHttpServletResponseImpl extends HttpServletResponseWrapper imp
     public void setLocale(final Locale loc) {
         if (!this.isProtectHeadersOnInclude()) {
             super.setLocale(loc);
-        }
-    }
-
-    @Override
-    public void setBufferSize(final int size) {
-        if (!this.isProtectHeadersOnInclude()) {
-            super.setBufferSize(size);
         }
     }
 

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -172,7 +172,7 @@ public class SlingHttpServletResponseImplTest {
         Mockito.verify(orig, never()).setContentLengthLong(33L);
         Mockito.verify(orig, never()).setContentType("text/plain");
         Mockito.verify(orig, never()).setLocale(null);
-        Mockito.verify(orig, never()).setBufferSize(4500);
+        Mockito.verify(orig, Mockito.times(1)).setBufferSize(4500);
 
         Mockito.verify(requestProcessor, atMostOnce()).setContentTypeHeaderState(Mockito.any());
 


### PR DESCRIPTION
- flag violation for committed responses if they were not committed due to sendError or sendRedirect
- do not protect buffer size by the header protection, as it is not a header property