### PR TITLE
Fixes for SLING-12845 and SLING-12844

### DIFF
--- a/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
@@ -318,8 +318,8 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
     @Override
     public void setContentType(final String type) {
         boolean isCommitedDueToSendErrorOrRedirect = this.isCommitted()
-                && (CommitReason.SEND_ERROR.equals(this.committedReason)
-                        || CommitReason.SEND_REDIRECT.equals(this.committedReason));
+                && (CommitReason.SEND_ERROR == this.committedReason
+                        || CommitReason.SEND_REDIRECT == this.committedReason);
         if (isCommitedDueToSendErrorOrRedirect || !isInclude()) {
             super.setContentType(type);
         } else {

--- a/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
@@ -94,8 +94,8 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
         this.firstSlingResponse = !(response instanceof SlingJakartaHttpServletResponse);
 
         if (firstSlingResponse) {
-            for (final StaticResponseHeader mapping : requestData.getSlingRequestProcessor()
-                    .getAdditionalResponseHeaders()) {
+            for (final StaticResponseHeader mapping :
+                    requestData.getSlingRequestProcessor().getAdditionalResponseHeaders()) {
                 response.addHeader(mapping.getResponseHeaderName(), mapping.getResponseHeaderValue());
             }
         }
@@ -384,7 +384,8 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
         // consumption errors when close to infinite recursive calls are made
         int nrOfOriginalMessages = 0;
         boolean gotCut = false;
-        Iterator<String> messagesIterator = requestData.getRequestProgressTracker().getMessages();
+        Iterator<String> messagesIterator =
+                requestData.getRequestProgressTracker().getMessages();
         LinkedList<String> lastMessages = new LinkedList<>();
         while (messagesIterator.hasNext()) {
             nrOfOriginalMessages++;
@@ -463,8 +464,8 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
     private String getMessage(@Nullable String currentContentType, @Nullable String setContentType) {
         String unmatchedStartTimers = findUnmatchedTimerStarts();
 
-        String allMessages = getLastMessagesOfProgressTracker().stream()
-                .collect(Collectors.joining(System.lineSeparator()));
+        String allMessages =
+                getLastMessagesOfProgressTracker().stream().collect(Collectors.joining(System.lineSeparator()));
 
         if (!isCheckContentTypeOnInclude()) {
             return String.format(
@@ -787,7 +788,8 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
     }
 
     private String removeContextPath(final String path) {
-        final String contextPath = this.getRequestData().getSlingRequest().getContextPath().concat("/");
+        final String contextPath =
+                this.getRequestData().getSlingRequest().getContextPath().concat("/");
         if (contextPath.length() > 1 && path.startsWith(contextPath)) {
             return path.substring(contextPath.length() - 1);
         }

--- a/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
@@ -160,11 +160,17 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
     }
 
     private boolean isProtectHeadersOnInclude() {
+        // the dispatch info is null on the initial request, so it defaults to false for
+        // the initial request always, and therefore checks for the configuration set
+        // only for includes
         return this.requestData.getDispatchingInfo() != null
                 && this.requestData.getDispatchingInfo().isProtectHeadersOnInclude();
     }
 
     private boolean isCheckContentTypeOnInclude() {
+        // the dispatch info is null on the initial request, so it defaults to false for
+        // the initial request always, and therefore checks for the configuration set
+        // only for includes
         return this.requestData.getDispatchingInfo() != null
                 && this.requestData.getDispatchingInfo().isCheckContentTypeOnInclude();
     }
@@ -229,13 +235,6 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
     public void setLocale(final Locale loc) {
         if (!this.isProtectHeadersOnInclude()) {
             super.setLocale(loc);
-        }
-    }
-
-    @Override
-    public void setBufferSize(final int size) {
-        if (!this.isProtectHeadersOnInclude()) {
-            super.setBufferSize(size);
         }
     }
 

--- a/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
+++ b/src/main/java/org/apache/sling/engine/impl/SlingJakartaHttpServletResponseImpl.java
@@ -52,7 +52,7 @@ public class SlingJakartaHttpServletResponseImpl extends HttpServletResponseWrap
      * The reason why the response was committed. This is used to determine whether
      * the change to the content type header can be ignored or not.
      */
-    public static enum CommitReason {
+    public enum CommitReason {
         SEND_ERROR,
         SEND_REDIRECT
     }

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -127,7 +127,7 @@ public class SlingHttpServletResponseImplTest {
     }
 
     @Test
-    public void testViolationChecksOnCommittedResponses() throws IOException {
+    public void testViolationChecksOnCommittedResponses() {
         final SlingJakartaHttpServletResponse orig = Mockito.mock(SlingJakartaHttpServletResponse.class);
         Mockito.when(orig.isCommitted()).thenReturn(true);
 

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -49,59 +49,102 @@ public class SlingHttpServletResponseImplTest {
 
     private static final String ACTIVE_SERVLET_NAME = "activeServlet";
     String[] logMessages = {
-        "0 TIMER_START{Request Processing}",
-        "6 COMMENT timer_end format is {<elapsed microseconds>,<timer name>} <optional message>",
-        "17 LOG Method=GET, PathInfo=null",
-        "20 TIMER_START{handleSecurity}",
-        "2104 TIMER_END{2081,handleSecurity} authenticator org.apache.sling.auth.core.impl.SlingAuthenticator@6367091e returns true",
-        "2478 TIMER_START{ResourceResolution}",
-        "2668 TIMER_END{189,ResourceResolution} URI=/content/slingshot.html resolves to Resource=JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot",
-        "2678 LOG Resource Path Info: SlingRequestPathInfo: path='/content/slingshot', selectorString='null', extension='html', suffix='null'",
-        "2678 TIMER_START{ServletResolution}",
-        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-        "3736 LOG Applying REQUESTfilters",
-        "3751 LOG Calling filter: com.composum.sling.nodes.mount.remote.RemoteRequestFilter",
-        "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
-        "3757 LOG Calling filter: org.apache.sling.i18n.impl.I18NFilter",
-        "4859 TIMER_END{135,/libs/slingshot/Component/head.html.jsp#1}",
-        "3765 LOG Calling filter: org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter",
-        "2678 TIMER_START{ServletResolution}",
-        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-        "2678 TIMER_START{ServletResolution}",
-        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-        "3774 LOG Applying Componentfilters",
-        "3797 TIMER_START{/libs/slingshot/Home/html.jsp#0}",
-        "3946 LOG Adding bindings took 18 microseconds",
-        "4405 LOG Including resource JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot (SlingRequestPathInfo: path='/content/slingshot', selectorString='head', extension='html', suffix='null')",
-        "4414 TIMER_START{resolveServlet(/content/slingshot)}",
-        "4670 TIMER_END{253,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Component/head.html.jsp",
-        "4673 LOG Applying Includefilters",
-        "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
-        "4749 LOG Adding bindings took 4 microseconds"
+            "0 TIMER_START{Request Processing}",
+            "6 COMMENT timer_end format is {<elapsed microseconds>,<timer name>} <optional message>",
+            "17 LOG Method=GET, PathInfo=null",
+            "20 TIMER_START{handleSecurity}",
+            "2104 TIMER_END{2081,handleSecurity} authenticator org.apache.sling.auth.core.impl.SlingAuthenticator@6367091e returns true",
+            "2478 TIMER_START{ResourceResolution}",
+            "2668 TIMER_END{189,ResourceResolution} URI=/content/slingshot.html resolves to Resource=JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot",
+            "2678 LOG Resource Path Info: SlingRequestPathInfo: path='/content/slingshot', selectorString='null', extension='html', suffix='null'",
+            "2678 TIMER_START{ServletResolution}",
+            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+            "3736 LOG Applying REQUESTfilters",
+            "3751 LOG Calling filter: com.composum.sling.nodes.mount.remote.RemoteRequestFilter",
+            "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
+            "3757 LOG Calling filter: org.apache.sling.i18n.impl.I18NFilter",
+            "4859 TIMER_END{135,/libs/slingshot/Component/head.html.jsp#1}",
+            "3765 LOG Calling filter: org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter",
+            "2678 TIMER_START{ServletResolution}",
+            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+            "2678 TIMER_START{ServletResolution}",
+            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+            "3774 LOG Applying Componentfilters",
+            "3797 TIMER_START{/libs/slingshot/Home/html.jsp#0}",
+            "3946 LOG Adding bindings took 18 microseconds",
+            "4405 LOG Including resource JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot (SlingRequestPathInfo: path='/content/slingshot', selectorString='head', extension='html', suffix='null')",
+            "4414 TIMER_START{resolveServlet(/content/slingshot)}",
+            "4670 TIMER_END{253,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Component/head.html.jsp",
+            "4673 LOG Applying Includefilters",
+            "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
+            "4749 LOG Adding bindings took 4 microseconds"
     };
 
     @Test
-    public void testNoViolationChecksOnCommitedResponse() {
+    public void testNoViolationChecksOnCommittedResponseWhenSendRedirect() throws IOException {
         final SlingJakartaHttpServletResponse orig = Mockito.mock(SlingJakartaHttpServletResponse.class);
         Mockito.when(orig.isCommitted()).thenReturn(true);
 
         final RequestData requestData = mock(RequestData.class);
         final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
         when(requestData.getDispatchingInfo()).thenReturn(info);
-        info.setProtectHeadersOnInclude(true);
+
+        final SlingJakartaHttpServletResponseImpl include = new SlingJakartaHttpServletResponseImpl(requestData, orig);
+        SlingJakartaHttpServletResponseImpl spyInclude = Mockito.spy(include);
+
+        spyInclude.sendRedirect("somewhere");
+
+        spyInclude.setContentType("someOtherType");
+        Mockito.verify(orig, times(1)).setContentType(Mockito.any());
+        Mockito.verify(spyInclude, never()).checkContentTypeOverride(Mockito.any());
+    }
+
+    @Test
+    public void testNoViolationChecksOnCommittedResponseWhenSendError() throws IOException {
+        final SlingJakartaHttpServletResponse orig = Mockito.mock(SlingJakartaHttpServletResponse.class);
+
+        final RequestData requestData = mock(RequestData.class);
+        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
+        when(requestData.getDispatchingInfo()).thenReturn(info);
+        when(requestData.getSlingRequestProcessor()).thenReturn(mock(SlingRequestProcessorImpl.class));
+
+        final SlingJakartaHttpServletResponseImpl include = new SlingJakartaHttpServletResponseImpl(requestData, orig);
+        SlingJakartaHttpServletResponseImpl spyInclude = Mockito.spy(include);
+
+        spyInclude.sendError(501);
+        // send error will eventually commit the response, let's mock this
+        Mockito.when(orig.isCommitted()).thenReturn(true);
+
+        spyInclude.setContentType("someOtherType");
+        Mockito.verify(orig, times(1)).setContentType(Mockito.any());
+        Mockito.verify(spyInclude, never()).checkContentTypeOverride(Mockito.any());
+    }
+
+    @Test
+    public void testViolationChecksOnCommittedResponses() throws IOException {
+        final SlingJakartaHttpServletResponse orig = Mockito.mock(SlingJakartaHttpServletResponse.class);
+        Mockito.when(orig.isCommitted()).thenReturn(true);
+
+        final RequestData requestData = mock(RequestData.class);
+        final DispatchingInfo info = new DispatchingInfo(DispatcherType.INCLUDE);
+        when(requestData.getDispatchingInfo()).thenReturn(info);
+        when(requestData.getSlingRequestProcessor()).thenReturn(mock(SlingRequestProcessorImpl.class));
+        final RequestProgressTracker rpt = mock(RequestProgressTracker.class);
+        when(rpt.getMessages()).thenReturn(new ArrayList<String>().iterator());
+        when(requestData.getRequestProgressTracker()).thenReturn(rpt);
 
         final SlingJakartaHttpServletResponseImpl include = new SlingJakartaHttpServletResponseImpl(requestData, orig);
         SlingJakartaHttpServletResponseImpl spyInclude = Mockito.spy(include);
 
         spyInclude.setContentType("someOtherType");
         Mockito.verify(orig, times(1)).setContentType(Mockito.any());
-        Mockito.verify(spyInclude, never()).checkContentTypeOverride(Mockito.any());
+        Mockito.verify(spyInclude, Mockito.times(1)).checkContentTypeOverride(Mockito.any());
     }
 
     @Test
@@ -112,8 +155,8 @@ public class SlingHttpServletResponseImplTest {
         when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
         dispatchingInfo.setProtectHeadersOnInclude(true);
 
-        final HttpServletResponse includeResponse =
-                new SlingJakartaHttpServletResponseImpl(requestData, originalResponse);
+        final HttpServletResponse includeResponse = new SlingJakartaHttpServletResponseImpl(requestData,
+                originalResponse);
 
         when(originalResponse.isCommitted()).thenReturn(false);
         includeResponse.reset();
@@ -134,8 +177,8 @@ public class SlingHttpServletResponseImplTest {
 
         // Simulate an error dispatching scenario on a uncommitted response
         DispatchingInfo dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
-        final HttpServletResponse includeResponse =
-                new SlingJakartaHttpServletResponseImpl(requestData, originalResponse);
+        final HttpServletResponse includeResponse = new SlingJakartaHttpServletResponseImpl(requestData,
+                originalResponse);
         dispatchingInfo.setProtectHeadersOnInclude(true);
         when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
         when(originalResponse.isCommitted()).thenReturn(false);

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -174,7 +174,7 @@ public class SlingHttpServletResponseImplTest {
         Mockito.verify(orig, never()).setContentLengthLong(33L);
         Mockito.verify(orig, never()).setContentType("text/plain");
         Mockito.verify(orig, never()).setLocale(null);
-        Mockito.verify(orig, never()).setBufferSize(4500);
+        Mockito.verify(orig, Mockito.times(1)).setBufferSize(4500);
 
         Mockito.verify(requestProcessor, atMostOnce()).setContentTypeHeaderState(Mockito.any());
 

--- a/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
+++ b/src/test/java/org/apache/sling/engine/impl/SlingHttpServletResponseImplTest.java
@@ -49,41 +49,41 @@ public class SlingHttpServletResponseImplTest {
 
     private static final String ACTIVE_SERVLET_NAME = "activeServlet";
     String[] logMessages = {
-            "0 TIMER_START{Request Processing}",
-            "6 COMMENT timer_end format is {<elapsed microseconds>,<timer name>} <optional message>",
-            "17 LOG Method=GET, PathInfo=null",
-            "20 TIMER_START{handleSecurity}",
-            "2104 TIMER_END{2081,handleSecurity} authenticator org.apache.sling.auth.core.impl.SlingAuthenticator@6367091e returns true",
-            "2478 TIMER_START{ResourceResolution}",
-            "2668 TIMER_END{189,ResourceResolution} URI=/content/slingshot.html resolves to Resource=JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot",
-            "2678 LOG Resource Path Info: SlingRequestPathInfo: path='/content/slingshot', selectorString='null', extension='html', suffix='null'",
-            "2678 TIMER_START{ServletResolution}",
-            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-            "3736 LOG Applying REQUESTfilters",
-            "3751 LOG Calling filter: com.composum.sling.nodes.mount.remote.RemoteRequestFilter",
-            "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
-            "3757 LOG Calling filter: org.apache.sling.i18n.impl.I18NFilter",
-            "4859 TIMER_END{135,/libs/slingshot/Component/head.html.jsp#1}",
-            "3765 LOG Calling filter: org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter",
-            "2678 TIMER_START{ServletResolution}",
-            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-            "2678 TIMER_START{ServletResolution}",
-            "2683 TIMER_START{resolveServlet(/content/slingshot)}",
-            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-            "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
-            "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
-            "3774 LOG Applying Componentfilters",
-            "3797 TIMER_START{/libs/slingshot/Home/html.jsp#0}",
-            "3946 LOG Adding bindings took 18 microseconds",
-            "4405 LOG Including resource JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot (SlingRequestPathInfo: path='/content/slingshot', selectorString='head', extension='html', suffix='null')",
-            "4414 TIMER_START{resolveServlet(/content/slingshot)}",
-            "4670 TIMER_END{253,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Component/head.html.jsp",
-            "4673 LOG Applying Includefilters",
-            "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
-            "4749 LOG Adding bindings took 4 microseconds"
+        "0 TIMER_START{Request Processing}",
+        "6 COMMENT timer_end format is {<elapsed microseconds>,<timer name>} <optional message>",
+        "17 LOG Method=GET, PathInfo=null",
+        "20 TIMER_START{handleSecurity}",
+        "2104 TIMER_END{2081,handleSecurity} authenticator org.apache.sling.auth.core.impl.SlingAuthenticator@6367091e returns true",
+        "2478 TIMER_START{ResourceResolution}",
+        "2668 TIMER_END{189,ResourceResolution} URI=/content/slingshot.html resolves to Resource=JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot",
+        "2678 LOG Resource Path Info: SlingRequestPathInfo: path='/content/slingshot', selectorString='null', extension='html', suffix='null'",
+        "2678 TIMER_START{ServletResolution}",
+        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+        "3736 LOG Applying REQUESTfilters",
+        "3751 LOG Calling filter: com.composum.sling.nodes.mount.remote.RemoteRequestFilter",
+        "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
+        "3757 LOG Calling filter: org.apache.sling.i18n.impl.I18NFilter",
+        "4859 TIMER_END{135,/libs/slingshot/Component/head.html.jsp#1}",
+        "3765 LOG Calling filter: org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter",
+        "2678 TIMER_START{ServletResolution}",
+        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+        "2678 TIMER_START{ServletResolution}",
+        "2683 TIMER_START{resolveServlet(/content/slingshot)}",
+        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+        "3724 TIMER_END{1040,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Home/html.jsp",
+        "3727 TIMER_END{1047,ServletResolution} URI=/content/slingshot.html handled by Servlet=/libs/slingshot/Home/html.jsp",
+        "3774 LOG Applying Componentfilters",
+        "3797 TIMER_START{/libs/slingshot/Home/html.jsp#0}",
+        "3946 LOG Adding bindings took 18 microseconds",
+        "4405 LOG Including resource JcrNodeResource, type=slingshot/Home, superType=null, path=/content/slingshot (SlingRequestPathInfo: path='/content/slingshot', selectorString='head', extension='html', suffix='null')",
+        "4414 TIMER_START{resolveServlet(/content/slingshot)}",
+        "4670 TIMER_END{253,resolveServlet(/content/slingshot)} Using servlet /libs/slingshot/Component/head.html.jsp",
+        "4673 LOG Applying Includefilters",
+        "4722 TIMER_START{/libs/slingshot/Component/head.html.jsp#1}",
+        "4749 LOG Adding bindings took 4 microseconds"
     };
 
     @Test
@@ -155,8 +155,8 @@ public class SlingHttpServletResponseImplTest {
         when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
         dispatchingInfo.setProtectHeadersOnInclude(true);
 
-        final HttpServletResponse includeResponse = new SlingJakartaHttpServletResponseImpl(requestData,
-                originalResponse);
+        final HttpServletResponse includeResponse =
+                new SlingJakartaHttpServletResponseImpl(requestData, originalResponse);
 
         when(originalResponse.isCommitted()).thenReturn(false);
         includeResponse.reset();
@@ -177,8 +177,8 @@ public class SlingHttpServletResponseImplTest {
 
         // Simulate an error dispatching scenario on a uncommitted response
         DispatchingInfo dispatchingInfo = new DispatchingInfo(DispatcherType.ERROR);
-        final HttpServletResponse includeResponse = new SlingJakartaHttpServletResponseImpl(requestData,
-                originalResponse);
+        final HttpServletResponse includeResponse =
+                new SlingJakartaHttpServletResponseImpl(requestData, originalResponse);
         dispatchingInfo.setProtectHeadersOnInclude(true);
         when(requestData.getDispatchingInfo()).thenReturn(dispatchingInfo);
         when(originalResponse.isCommitted()).thenReturn(false);


### PR DESCRIPTION
- flag violation for committed responses if they were not committed due to sendError or sendRedirect
- do not protect buffer size by the header protection, as it is not a header property
merge from https://github.com/apache/sling-org-apache-sling-engine/pull/64